### PR TITLE
Bug fixes: Made Extraction more robust

### DIFF
--- a/src/analysis/pointer_safety.rs
+++ b/src/analysis/pointer_safety.rs
@@ -162,13 +162,57 @@ pub fn check_parsed_function_for_pointers(
             }
         }
 
-        if let Some(error) = check_parsed_statement_for_pointers_with_return_type(
-            stmt,
-            in_unsafe_scope,
-            &safe_pointer_vars,
-            Some(&function.return_type),
-        ) {
-            errors.push(format!("In function '{}': {}", function.name, error));
+        match stmt {
+            Statement::If {
+                condition,
+                then_branch,
+                else_branch,
+                location,
+            } if !in_unsafe_scope => {
+                if let Some(op) = contains_pointer_operation(condition, &safe_pointer_vars) {
+                    errors.push(format!(
+                        "In function '{}': Unsafe pointer {} in condition at line {}: pointer operations require unsafe context",
+                        function.name, op, location.line
+                    ));
+                }
+
+                for error in check_statements_for_pointers_with_unsafe_tracking(
+                    then_branch,
+                    0,
+                    &safe_pointer_vars,
+                ) {
+                    errors.push(format!("In function '{}': {}", function.name, error));
+                }
+
+                if let Some(else_stmts) = else_branch {
+                    for error in check_statements_for_pointers_with_unsafe_tracking(
+                        else_stmts,
+                        0,
+                        &safe_pointer_vars,
+                    ) {
+                        errors.push(format!("In function '{}': {}", function.name, error));
+                    }
+                }
+            }
+            Statement::Block(statements) if !in_unsafe_scope => {
+                for error in check_statements_for_pointers_with_unsafe_tracking(
+                    statements,
+                    0,
+                    &safe_pointer_vars,
+                ) {
+                    errors.push(format!("In function '{}': {}", function.name, error));
+                }
+            }
+            _ => {
+                if let Some(error) = check_parsed_statement_for_pointers_with_return_type(
+                    stmt,
+                    in_unsafe_scope,
+                    &safe_pointer_vars,
+                    Some(&function.return_type),
+                ) {
+                    errors.push(format!("In function '{}': {}", function.name, error));
+                }
+            }
         }
     }
 
@@ -471,10 +515,48 @@ fn check_statements_for_pointers_with_unsafe_tracking(
 
         let in_unsafe_scope = unsafe_depth > 0;
 
-        if let Some(error) =
-            check_parsed_statement_for_pointers(stmt, in_unsafe_scope, safe_pointer_vars)
-        {
-            errors.push(error);
+        match stmt {
+            Statement::If {
+                condition,
+                then_branch,
+                else_branch,
+                location,
+            } if !in_unsafe_scope => {
+                if let Some(op) = contains_pointer_operation(condition, safe_pointer_vars) {
+                    errors.push(format!(
+                        "Unsafe pointer {} in condition at line {}: pointer operations require unsafe context",
+                        op, location.line
+                    ));
+                }
+
+                errors.extend(check_statements_for_pointers_with_unsafe_tracking(
+                    then_branch,
+                    0,
+                    safe_pointer_vars,
+                ));
+
+                if let Some(else_stmts) = else_branch {
+                    errors.extend(check_statements_for_pointers_with_unsafe_tracking(
+                        else_stmts,
+                        0,
+                        safe_pointer_vars,
+                    ));
+                }
+            }
+            Statement::Block(statements) if !in_unsafe_scope => {
+                errors.extend(check_statements_for_pointers_with_unsafe_tracking(
+                    statements,
+                    0,
+                    safe_pointer_vars,
+                ));
+            }
+            _ => {
+                if let Some(error) =
+                    check_parsed_statement_for_pointers(stmt, in_unsafe_scope, safe_pointer_vars)
+                {
+                    errors.push(error);
+                }
+            }
         }
     }
 

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -16,44 +16,22 @@ pub fn check_unsafe_propagation_with_external(
     external_annotations: Option<&ExternalAnnotations>,
 ) -> Vec<String> {
     let mut errors = Vec::new();
-    let mut unsafe_depth = 0;
 
     // Collect callable parameters - parameters whose type is or contains a template type parameter
     // e.g., for template<typename F> void foo(F&& write_fn), "write_fn" is a callable parameter
     let callable_params =
         get_callable_parameters(&function.parameters, &function.template_parameters);
 
-    // Check each statement in the function
-    for stmt in &function.body {
-        // Track unsafe scope depth
-        match stmt {
-            Statement::EnterUnsafe => {
-                unsafe_depth += 1;
-                continue;
-            }
-            Statement::ExitUnsafe => {
-                if unsafe_depth > 0 {
-                    unsafe_depth -= 1;
-                }
-                continue;
-            }
-            _ => {}
-        }
-
-        // Skip checking if we're in an unsafe block
-        let in_unsafe_scope = unsafe_depth > 0;
-
-        if let Some(error) = check_statement_for_unsafe_calls_with_external(
-            stmt,
-            safety_context,
-            known_safe_functions,
-            external_annotations,
-            &function.template_parameters,
-            &callable_params,
-            in_unsafe_scope,
-        ) {
-            errors.push(format!("In function '{}': {}", function.name, error));
-        }
+    for error in check_statements_with_unsafe_tracking(
+        &function.body,
+        safety_context,
+        known_safe_functions,
+        external_annotations,
+        &function.template_parameters,
+        &callable_params,
+        0,
+    ) {
+        errors.push(format!("In function '{}': {}", function.name, error));
     }
 
     errors
@@ -186,16 +164,73 @@ fn check_statements_with_unsafe_tracking(
 
         let in_unsafe_scope = unsafe_depth > 0;
 
-        if let Some(error) = check_statement_for_unsafe_calls_with_external(
-            stmt,
-            safety_context,
-            known_safe_functions,
-            external_annotations,
-            template_params,
-            callable_params,
-            in_unsafe_scope,
-        ) {
-            errors.push(error);
+        match stmt {
+            Statement::If {
+                condition,
+                then_branch,
+                else_branch,
+                location,
+            } if !in_unsafe_scope => {
+                if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                    condition,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ) {
+                    errors.push(format!(
+                        "Calling unsafe function '{}' in condition at line {} requires unsafe context",
+                        unsafe_func, location.line
+                    ));
+                }
+
+                errors.extend(check_statements_with_unsafe_tracking(
+                    then_branch,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                    0,
+                ));
+
+                if let Some(else_stmts) = else_branch {
+                    errors.extend(check_statements_with_unsafe_tracking(
+                        else_stmts,
+                        safety_context,
+                        known_safe_functions,
+                        external_annotations,
+                        template_params,
+                        callable_params,
+                        0,
+                    ));
+                }
+            }
+            Statement::Block(statements) if !in_unsafe_scope => {
+                errors.extend(check_statements_with_unsafe_tracking(
+                    statements,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                    0,
+                ));
+            }
+            _ => {
+                if let Some(error) = check_statement_for_unsafe_calls_with_external(
+                    stmt,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                    in_unsafe_scope,
+                ) {
+                    errors.push(error);
+                }
+            }
         }
     }
 

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -216,7 +216,7 @@ fn check_for_unsafe_annotation(entity: &Entity) -> bool {
     for line in preceding.iter().rev() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
-            return false;
+            continue;
         }
         let is_line_comment = trimmed.starts_with("//");
         let is_block_comment_single_line = trimmed.contains("/*") && trimmed.contains("*/");
@@ -2173,14 +2173,35 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                 statements.push(Statement::ExitScope);
             }
             EntityKind::ForStmt | EntityKind::WhileStmt | EntityKind::DoStmt => {
-                // Loop detected - add loop markers
                 statements.push(Statement::EnterLoop);
-                // Extract loop body (usually a compound statement)
-                for loop_child in child.get_children() {
-                    if loop_child.get_kind() == EntityKind::CompoundStmt {
-                        statements.extend(extract_compound_statement(&loop_child));
+
+                let loop_children: Vec<Entity> = child.get_children().into_iter().collect();
+
+                // Libclang exposes loop control pieces as siblings of the loop body:
+                //   for:   init, condition, increment, body
+                //   while: condition, body
+                //   do:    body, condition
+                // Only the body should become loop contents; the other children are
+                // control expressions and declarations, not statements executed inside
+                // the loop block.
+                let body = if child.get_kind() == EntityKind::DoStmt {
+                    loop_children.first()
+                } else {
+                    loop_children.last()
+                };
+
+                if let Some(loop_body) = body {
+                    // Braced loop bodies arrive as CompoundStmt. Unbraced loop bodies
+                    // arrive as the concrete single statement cursor, such as
+                    // BinaryOperator for `x = y`, UnaryOperator for `++i`, CallExpr
+                    // for `f()`, or DeclStmt for a declaration.
+                    if loop_body.get_kind() == EntityKind::CompoundStmt {
+                        statements.extend(extract_compound_statement(loop_body));
+                    } else {
+                        statements.extend(extract_single_statement(loop_body));
                     }
                 }
+
                 statements.push(Statement::ExitLoop);
             }
             EntityKind::IfStmt => {
@@ -2191,16 +2212,15 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                 let mut else_branch = None;
 
                 // Parse the if statement structure
+                let mut condition_seen = false;
                 let mut i = 0;
                 while i < children.len() {
                     let child_kind = children[i].get_kind();
 
-                    if child_kind == EntityKind::UnexposedExpr
-                        || child_kind == EntityKind::BinaryOperator
-                    {
-                        // This is likely the condition
+                    if !condition_seen && child_kind != EntityKind::CompoundStmt {
                         if let Some(expr) = extract_expression(&children[i]) {
                             condition = expr;
+                            condition_seen = true;
                         }
                     } else if child_kind == EntityKind::CompoundStmt {
                         // This is a branch
@@ -2208,6 +2228,15 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                             then_branch = extract_compound_statement(&children[i]);
                         } else {
                             else_branch = Some(extract_compound_statement(&children[i]));
+                        }
+                    } else {
+                        let branch = extract_single_statement(&children[i]);
+                        if !branch.is_empty() {
+                            if then_branch.is_empty() {
+                                then_branch = branch;
+                            } else {
+                                else_branch = Some(branch);
+                            }
                         }
                     }
                     i += 1;
@@ -2326,6 +2355,96 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
     }
 
     statements
+}
+
+// Extract one statement cursor used where C++ allows an unbraced substatement,
+// such as `if (x) f();` or `while (x) ++i;`. This helper intentionally takes
+// the already-selected branch/body cursor; callers must not pass a whole IfStmt
+// or ForStmt because those cursors also contain condition/control children.
+fn extract_single_statement(entity: &Entity) -> Vec<Statement> {
+    let location = extract_location(entity);
+
+    match entity.get_kind() {
+        EntityKind::CompoundStmt => extract_compound_statement(entity),
+        EntityKind::DeclStmt => {
+            let mut statements = Vec::new();
+
+            for decl_child in entity.get_children() {
+                if decl_child.get_kind() == EntityKind::VarDecl {
+                    let var = extract_variable(&decl_child);
+                    statements.push(Statement::VariableDecl(var.clone()));
+
+                    for init_child in decl_child.get_children() {
+                        if let Some(expr) = extract_expression(&init_child) {
+                            if var.is_reference {
+                                statements.push(Statement::ReferenceBinding {
+                                    name: var.name.clone(),
+                                    target: expr,
+                                    is_mutable: !var.is_const,
+                                    location: extract_location(&decl_child),
+                                });
+                            } else {
+                                statements.push(Statement::Assignment {
+                                    lhs: Expression::Variable(var.name.clone()),
+                                    rhs: expr,
+                                    location: extract_location(&decl_child),
+                                });
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            statements
+        }
+        EntityKind::BinaryOperator => {
+            let children: Vec<Entity> = entity.get_children().into_iter().collect();
+            if children.len() == 2 {
+                if let (Some(lhs), Some(rhs)) = (
+                    extract_expression(&children[0]),
+                    extract_expression(&children[1]),
+                ) {
+                    return vec![Statement::Assignment { lhs, rhs, location }];
+                }
+            }
+            Vec::new()
+        }
+        EntityKind::CallExpr => {
+            if let Some(expr) = extract_expression(entity) {
+                match expr {
+                    Expression::FunctionCall { name, args } => {
+                        vec![Statement::FunctionCall {
+                            name,
+                            args,
+                            location,
+                        }]
+                    }
+                    _ => vec![Statement::ExpressionStatement { expr, location }],
+                }
+            } else {
+                Vec::new()
+            }
+        }
+        EntityKind::ReturnStmt => {
+            let return_expr = entity
+                .get_children()
+                .into_iter()
+                .find_map(|c| extract_expression(&c));
+            vec![Statement::Return(return_expr)]
+        }
+        EntityKind::UnexposedExpr
+        | EntityKind::UnaryOperator
+        | EntityKind::NewExpr
+        | EntityKind::DeleteExpr => {
+            if let Some(expr) = extract_expression(entity) {
+                vec![Statement::ExpressionStatement { expr, location }]
+            } else {
+                Vec::new()
+            }
+        }
+        _ => Vec::new(),
+    }
 }
 
 /// Extract pack expansion information from a PackExpansionExpr AST node


### PR DESCRIPTION
  ## Summary

  Fix several parser and analysis gaps that caused RustyCpp to miss unsafe operations in safe code.

  ## Changes

  - Add support for unbraced `if` / `else` bodies.
    Clang does not represent unbraced branch bodies as `CompoundStmt`; it exposes the concrete statement cursor directly. RustyCpp now parses those single-statement branch bodies instead of dropping them.

  - Fix conditional parsing for `if`, `for`, `while`, and `do` statements.
    Conditions can appear as `CallExpr`, `CXXOperatorCallExpr`, declarations, casts, or wrapped expressions, not only `BinaryOperator` / `UnaryOperator`. The parser now separates condition/control cursors
    from actual body cursors so condition expressions are not mistaken for loop or branch bodies.

  - Allow safety annotations to skip blank lines.
    `@safe` / `@unsafe` annotations now still attach to the next function when separated by empty lines.

  - Report all nested analysis errors instead of only the first.
    Recursive checks in pointer safety and unsafe propagation now collect errors from nested `if` / `else` / block bodies rather than returning only the first finding.

  ## Motivation

  These issues caused unsafe operations in safe code to be silently missed, especially in unbraced branches and nested constructs. For example, unsafe calls inside `if (...) stmt; else stmt;` could be dropped
  before reaching the safety analyses.