### PR TITLE
Automated annotator

### DIFF
--- a/src/analysis/alignment_safety.rs
+++ b/src/analysis/alignment_safety.rs
@@ -267,6 +267,21 @@ fn analyze_statement_alignment(
                 tracker.exit_scope();
             }
         }
+        Statement::Switch {
+            condition, cases, ..
+        } => {
+            if !in_unsafe {
+                check_expr_alignment(condition, tracker, func_name, errors);
+            }
+
+            for case in cases {
+                tracker.enter_scope();
+                for stmt in &case.statements {
+                    analyze_statement_alignment(stmt, tracker, func_name, errors, in_unsafe);
+                }
+                tracker.exit_scope();
+            }
+        }
 
         Statement::Block(stmts) => {
             tracker.enter_scope();

--- a/src/analysis/alignment_safety.rs
+++ b/src/analysis/alignment_safety.rs
@@ -323,7 +323,7 @@ fn update_alignment_from_expr(ptr: &str, expr: &Expression, tracker: &mut Alignm
             tracker.set_alignment(ptr, AlignmentInfo::aligned(8, "unknown".to_string()));
         }
 
-        Expression::PointerArithmetic { pointer, op: _ } => {
+        Expression::PointerArithmetic { pointer, op: _, .. } => {
             // Pointer arithmetic changes offset - but we don't know by how much without the offset
             // For now, mark as potentially misaligned (offset unknown) for char* arithmetic
             if let Some(source) = extract_var_name(pointer) {
@@ -472,7 +472,7 @@ fn check_arithmetic_alignment_in_cast(
     errors: &mut Vec<String>,
 ) {
     match expr {
-        Expression::PointerArithmetic { pointer, op: _ } => {
+        Expression::PointerArithmetic { pointer, op: _, .. } => {
             // Check if the arithmetic could cause misalignment
             if let Some(source) = extract_var_name(pointer) {
                 if let Some(info) = tracker.get_alignment(&source) {

--- a/src/analysis/array_bounds.rs
+++ b/src/analysis/array_bounds.rs
@@ -250,6 +250,21 @@ fn analyze_statement_bounds(
                 tracker.exit_scope();
             }
         }
+        Statement::Switch {
+            condition, cases, ..
+        } => {
+            if !in_unsafe {
+                check_expr_bounds(condition, tracker, func_name, errors);
+            }
+
+            for case in cases {
+                tracker.enter_scope();
+                for stmt in &case.statements {
+                    analyze_statement_bounds(stmt, tracker, func_name, errors, in_unsafe);
+                }
+                tracker.exit_scope();
+            }
+        }
 
         // EnterLoop/ExitLoop markers are handled through scope tracking
         Statement::EnterLoop => {

--- a/src/analysis/const_propagation.rs
+++ b/src/analysis/const_propagation.rs
@@ -212,6 +212,18 @@ fn check_function_for_const_violations(
                     errors.extend(else_errors);
                 }
             }
+            Statement::Switch { cases, .. } => {
+                for case in cases {
+                    let case_errors = check_statements_for_const_violations(
+                        &case.statements,
+                        const_vars,
+                        class_info,
+                        unsafe_depth,
+                        safe_functions,
+                    );
+                    errors.extend(case_errors);
+                }
+            }
             Statement::Block(stmts) => {
                 let block_errors = check_statements_for_const_violations(
                     stmts,

--- a/src/analysis/inheritance_safety.rs
+++ b/src/analysis/inheritance_safety.rs
@@ -384,6 +384,26 @@ fn check_statement_safety(
                 }
             }
         }
+        Statement::Switch {
+            condition, cases, ..
+        } => {
+            errors.extend(check_expression_safety(
+                condition,
+                method_name,
+                class_name,
+                interface_name,
+            ));
+            for case in cases {
+                for s in &case.statements {
+                    errors.extend(check_statement_safety(
+                        s,
+                        method_name,
+                        class_name,
+                        interface_name,
+                    ));
+                }
+            }
+        }
         Statement::Block(stmts) => {
             for s in stmts {
                 errors.extend(check_statement_safety(

--- a/src/analysis/initialization_tracking.rs
+++ b/src/analysis/initialization_tracking.rs
@@ -272,6 +272,24 @@ fn analyze_statement_init(
                 tracker.merge_branch(&else_tracker);
             }
         }
+        Statement::Switch {
+            condition, cases, ..
+        } => {
+            check_expr_init(condition, tracker, func_name, errors);
+
+            let mut case_trackers = Vec::new();
+            for case in cases {
+                let mut case_tracker = tracker.snapshot();
+                for stmt in &case.statements {
+                    analyze_statement_init(stmt, &mut case_tracker, func_name, errors);
+                }
+                case_trackers.push(case_tracker);
+            }
+
+            for case_tracker in &case_trackers {
+                tracker.merge_branch(case_tracker);
+            }
+        }
 
         Statement::Block(stmts) => {
             tracker.enter_scope();

--- a/src/analysis/lambda_capture_safety.rs
+++ b/src/analysis/lambda_capture_safety.rs
@@ -326,7 +326,7 @@ fn check_expression_for_this_capture(
     errors: &mut Vec<String>,
 ) {
     match expr {
-        Expression::Lambda { captures } => {
+        Expression::Lambda { captures, .. } => {
             for capture in captures {
                 if matches!(capture, LambdaCaptureKind::This) {
                     errors.push(format!(
@@ -398,7 +398,7 @@ fn check_for_escape_via_call(expr: &Expression, ctx: &mut LambdaContext, functio
 
 fn extract_lambda_captures(expr: &Expression) -> Option<(Vec<String>, bool)> {
     match expr {
-        Expression::Lambda { captures } => {
+        Expression::Lambda { captures, .. } => {
             let mut ref_captures = Vec::new();
             let mut has_default_ref = false;
 
@@ -445,6 +445,7 @@ mod tests {
     fn test_this_capture_in_safe_is_error() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::This],
+            body: Vec::new(),
         };
 
         let mut errors = Vec::new();
@@ -458,6 +459,7 @@ mod tests {
     fn test_copy_capture_in_safe_is_ok() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::ByCopy("x".to_string())],
+            body: Vec::new(),
         };
 
         // Copy captures never cause errors
@@ -470,6 +472,7 @@ mod tests {
     fn test_default_copy_capture_in_safe_is_ok() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::DefaultCopy],
+            body: Vec::new(),
         };
 
         let (ref_captures, has_default_ref) = extract_lambda_captures(&lambda).unwrap();
@@ -483,6 +486,7 @@ mod tests {
             captures: vec![LambdaCaptureKind::Init {
                 name: "y".to_string(),
             }],
+            body: Vec::new(),
         };
 
         let (ref_captures, has_default_ref) = extract_lambda_captures(&lambda).unwrap();
@@ -494,6 +498,7 @@ mod tests {
     fn test_ref_capture_extraction() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::ByRef("x".to_string())],
+            body: Vec::new(),
         };
 
         let (ref_captures, has_default_ref) = extract_lambda_captures(&lambda).unwrap();
@@ -505,6 +510,7 @@ mod tests {
     fn test_default_ref_capture_extraction() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::DefaultRef],
+            body: Vec::new(),
         };
 
         let (ref_captures, has_default_ref) = extract_lambda_captures(&lambda).unwrap();

--- a/src/analysis/lambda_capture_safety.rs
+++ b/src/analysis/lambda_capture_safety.rs
@@ -445,6 +445,7 @@ mod tests {
     fn test_this_capture_in_safe_is_error() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::This],
+            capture_initializers: Vec::new(),
             body: Vec::new(),
         };
 
@@ -459,6 +460,7 @@ mod tests {
     fn test_copy_capture_in_safe_is_ok() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::ByCopy("x".to_string())],
+            capture_initializers: Vec::new(),
             body: Vec::new(),
         };
 
@@ -472,6 +474,7 @@ mod tests {
     fn test_default_copy_capture_in_safe_is_ok() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::DefaultCopy],
+            capture_initializers: Vec::new(),
             body: Vec::new(),
         };
 
@@ -486,6 +489,7 @@ mod tests {
             captures: vec![LambdaCaptureKind::Init {
                 name: "y".to_string(),
             }],
+            capture_initializers: Vec::new(),
             body: Vec::new(),
         };
 
@@ -498,6 +502,7 @@ mod tests {
     fn test_ref_capture_extraction() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::ByRef("x".to_string())],
+            capture_initializers: Vec::new(),
             body: Vec::new(),
         };
 
@@ -510,6 +515,7 @@ mod tests {
     fn test_default_ref_capture_extraction() {
         let lambda = Expression::Lambda {
             captures: vec![LambdaCaptureKind::DefaultRef],
+            capture_initializers: Vec::new(),
             body: Vec::new(),
         };
 

--- a/src/analysis/lambda_capture_safety.rs
+++ b/src/analysis/lambda_capture_safety.rs
@@ -232,6 +232,16 @@ fn collect_lambdas_and_escapes(
                     collect_lambdas_and_escapes(else_stmts, function_name, ctx, unsafe_depth);
                 }
             }
+            Statement::Switch { cases, .. } => {
+                for case in cases {
+                    collect_lambdas_and_escapes(
+                        &case.statements,
+                        function_name,
+                        ctx,
+                        unsafe_depth,
+                    );
+                }
+            }
             Statement::Block(inner_stmts) => {
                 collect_lambdas_and_escapes(inner_stmts, function_name, ctx, unsafe_depth);
             }
@@ -289,6 +299,16 @@ fn check_this_captures_errors(
                 check_this_captures_errors(then_branch, function_name, errors, unsafe_depth);
                 if let Some(else_stmts) = else_branch {
                     check_this_captures_errors(else_stmts, function_name, errors, unsafe_depth);
+                }
+            }
+            Statement::Switch { cases, .. } => {
+                for case in cases {
+                    check_this_captures_errors(
+                        &case.statements,
+                        function_name,
+                        errors,
+                        unsafe_depth,
+                    );
                 }
             }
             Statement::Block(inner_stmts) => {

--- a/src/analysis/liveness.rs
+++ b/src/analysis/liveness.rs
@@ -206,6 +206,15 @@ impl LivenessAnalyzer {
 
                 self.in_conditional_depth -= 1;
             }
+            IrStatement::Switch { cases } => {
+                self.in_conditional_depth += 1;
+
+                for case in cases {
+                    self.collect_uses(case);
+                }
+
+                self.in_conditional_depth -= 1;
+            }
 
             IrStatement::PackExpansion {
                 pack_name,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -626,6 +626,11 @@ fn collect_loop_local_vars(
                     collect_loop_local_vars(else_stmts, loop_local_vars);
                 }
             }
+            crate::ir::IrStatement::Switch { cases } => {
+                for case in cases {
+                    collect_loop_local_vars(case, loop_local_vars);
+                }
+            }
             _ => {}
         }
     }
@@ -703,6 +708,13 @@ fn check_loop_local_escape(
                 }
             }
         }
+        crate::ir::IrStatement::Switch { cases } => {
+            for case in cases {
+                for stmt in case {
+                    check_loop_local_escape(stmt, loop_local_vars, header_cache, errors);
+                }
+            }
+        }
         _ => {}
     }
 }
@@ -758,6 +770,18 @@ fn check_statement_for_loop_errors(
             }
             if let Some(else_stmts) = else_branch {
                 for stmt in else_stmts {
+                    check_statement_for_loop_errors(
+                        stmt,
+                        state_after_first,
+                        loop_local_vars,
+                        errors,
+                    );
+                }
+            }
+        }
+        crate::ir::IrStatement::Switch { cases } => {
+            for case in cases {
+                for stmt in case {
                     check_statement_for_loop_errors(
                         stmt,
                         state_after_first,
@@ -1775,6 +1799,44 @@ fn process_statement(
                 // No else branch: merge with original state
                 // Variable is moved if moved in then branch (aggressive approach)
                 ownership_tracker.merge_states(&state_after_then, &state_before_if);
+            }
+        }
+
+        crate::ir::IrStatement::Switch { cases } => {
+            if ownership_tracker.is_in_unsafe_block() {
+                return;
+            }
+
+            let state_before_switch = ownership_tracker.clone_state();
+            let mut merged_state: Option<TrackerState> = None;
+
+            for case in cases {
+                ownership_tracker.restore_state(&state_before_switch);
+
+                for stmt in case {
+                    process_statement(
+                        stmt,
+                        ownership_tracker,
+                        this_tracker,
+                        errors,
+                        header_cache,
+                        function,
+                    );
+                }
+
+                let state_after_case = ownership_tracker.clone_state();
+                if let Some(current_merged) = &merged_state {
+                    ownership_tracker.restore_state(current_merged);
+                    ownership_tracker.merge_states(current_merged, &state_after_case);
+                    merged_state = Some(ownership_tracker.clone_state());
+                } else {
+                    merged_state = Some(state_after_case);
+                }
+            }
+
+            if let Some(state_after_cases) = merged_state {
+                ownership_tracker.restore_state(&state_before_switch);
+                ownership_tracker.merge_states(&state_after_cases, &state_before_switch);
             }
         }
 

--- a/src/analysis/null_safety.rs
+++ b/src/analysis/null_safety.rs
@@ -243,6 +243,24 @@ fn analyze_statement_null_safety(
                 tracker.merge_branch(&else_tracker);
             }
         }
+        Statement::Switch {
+            condition, cases, ..
+        } => {
+            check_expr_null_safety(condition, tracker, func_name, errors);
+
+            let mut case_trackers = Vec::new();
+            for case in cases {
+                let mut case_tracker = tracker.snapshot();
+                for stmt in &case.statements {
+                    analyze_statement_null_safety(stmt, &mut case_tracker, func_name, errors);
+                }
+                case_trackers.push(case_tracker);
+            }
+
+            for case_tracker in &case_trackers {
+                tracker.merge_branch(case_tracker);
+            }
+        }
 
         Statement::Block(stmts) => {
             tracker.enter_scope();

--- a/src/analysis/pointer_provenance.rs
+++ b/src/analysis/pointer_provenance.rs
@@ -202,6 +202,19 @@ fn analyze_statement_provenance(
                 tracker.exit_scope();
             }
         }
+        Statement::Switch {
+            condition, cases, ..
+        } => {
+            check_expr_provenance(condition, tracker, func_name, errors);
+
+            for case in cases {
+                tracker.enter_scope();
+                for stmt in &case.statements {
+                    analyze_statement_provenance(stmt, tracker, func_name, errors);
+                }
+                tracker.exit_scope();
+            }
+        }
 
         Statement::Block(stmts) => {
             tracker.enter_scope();

--- a/src/analysis/pointer_safety.rs
+++ b/src/analysis/pointer_safety.rs
@@ -1480,6 +1480,7 @@ mod tests {
         let expr = Expression::PointerArithmetic {
             pointer: Box::new(Expression::Variable("ptr".to_string())),
             op: "+".to_string(),
+            offset: None,
         };
         assert_eq!(
             contains_pointer_operation(&expr, &empty_safe_vars()),
@@ -1494,6 +1495,7 @@ mod tests {
             expr: Expression::PointerArithmetic {
                 pointer: Box::new(Expression::Variable("ptr".to_string())),
                 op: "++".to_string(),
+                offset: None,
             },
             location: SourceLocation {
                 file: "test.cpp".to_string(),
@@ -1516,6 +1518,7 @@ mod tests {
             expr: Expression::PointerArithmetic {
                 pointer: Box::new(Expression::Variable("ptr".to_string())),
                 op: "++".to_string(),
+                offset: None,
             },
             location: SourceLocation {
                 file: "test.cpp".to_string(),

--- a/src/analysis/pointer_safety.rs
+++ b/src/analysis/pointer_safety.rs
@@ -194,6 +194,28 @@ pub fn check_parsed_function_for_pointers(
                     }
                 }
             }
+            Statement::Switch {
+                condition,
+                cases,
+                location,
+            } if !in_unsafe_scope => {
+                if let Some(op) = contains_pointer_operation(condition, &safe_pointer_vars) {
+                    errors.push(format!(
+                        "In function '{}': Unsafe pointer {} in switch condition at line {}: pointer operations require unsafe context",
+                        function.name, op, location.line
+                    ));
+                }
+
+                for case in cases {
+                    for error in check_statements_for_pointers_with_unsafe_tracking(
+                        &case.statements,
+                        0,
+                        &safe_pointer_vars,
+                    ) {
+                        errors.push(format!("In function '{}': {}", function.name, error));
+                    }
+                }
+            }
             Statement::Block(statements) if !in_unsafe_scope => {
                 for error in check_statements_for_pointers_with_unsafe_tracking(
                     statements,
@@ -415,6 +437,25 @@ fn check_statements_for_std_move_on_ref(
                     );
                 }
             }
+            Statement::Switch {
+                condition, cases, ..
+            } => {
+                if let Some(error) =
+                    check_expression_for_std_move_on_ref(condition, reference_vars, 0)
+                {
+                    errors.push(format!("In function '{}': {}", function_name, error));
+                }
+
+                for case in cases {
+                    check_statements_for_std_move_on_ref(
+                        &case.statements,
+                        function_name,
+                        reference_vars,
+                        unsafe_depth,
+                        errors,
+                    );
+                }
+            }
             Statement::Block(statements) => {
                 check_statements_for_std_move_on_ref(
                     statements,
@@ -538,6 +579,26 @@ fn check_statements_for_pointers_with_unsafe_tracking(
                 if let Some(else_stmts) = else_branch {
                     errors.extend(check_statements_for_pointers_with_unsafe_tracking(
                         else_stmts,
+                        0,
+                        safe_pointer_vars,
+                    ));
+                }
+            }
+            Statement::Switch {
+                condition,
+                cases,
+                location,
+            } if !in_unsafe_scope => {
+                if let Some(op) = contains_pointer_operation(condition, safe_pointer_vars) {
+                    errors.push(format!(
+                        "Unsafe pointer {} in switch condition at line {}: pointer operations require unsafe context",
+                        op, location.line
+                    ));
+                }
+
+                for case in cases {
+                    errors.extend(check_statements_for_pointers_with_unsafe_tracking(
+                        &case.statements,
                         0,
                         safe_pointer_vars,
                     ));
@@ -813,6 +874,29 @@ pub fn check_parsed_statement_for_pointers_with_return_type(
                 );
                 if !else_errors.is_empty() {
                     return Some(else_errors.into_iter().next().unwrap());
+                }
+            }
+        }
+        Statement::Switch {
+            condition,
+            cases,
+            location,
+        } => {
+            if let Some(op) = contains_pointer_operation(condition, safe_pointer_vars) {
+                return Some(format!(
+                    "Unsafe pointer {} in switch condition at line {}: pointer operations require unsafe context",
+                    op, location.line
+                ));
+            }
+
+            for case in cases {
+                let case_errors = check_statements_for_pointers_with_unsafe_tracking(
+                    &case.statements,
+                    0,
+                    safe_pointer_vars,
+                );
+                if !case_errors.is_empty() {
+                    return Some(case_errors.into_iter().next().unwrap());
                 }
             }
         }

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -207,6 +207,37 @@ fn check_statements_with_unsafe_tracking(
                     ));
                 }
             }
+            Statement::Switch {
+                condition,
+                cases,
+                location,
+            } if !in_unsafe_scope => {
+                if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                    condition,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ) {
+                    errors.push(format!(
+                        "Calling unsafe function '{}' in switch condition at line {} requires unsafe context",
+                        unsafe_func, location.line
+                    ));
+                }
+
+                for case in cases {
+                    errors.extend(check_statements_with_unsafe_tracking(
+                        &case.statements,
+                        safety_context,
+                        known_safe_functions,
+                        external_annotations,
+                        template_params,
+                        callable_params,
+                        0,
+                    ));
+                }
+            }
             Statement::Block(statements) if !in_unsafe_scope => {
                 errors.extend(check_statements_with_unsafe_tracking(
                     statements,
@@ -400,6 +431,40 @@ fn check_statement_for_unsafe_calls_with_external(
                 );
                 if !else_errors.is_empty() {
                     return Some(else_errors.into_iter().next().unwrap());
+                }
+            }
+        }
+        Statement::Switch {
+            condition,
+            cases,
+            location,
+        } => {
+            if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                condition,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ) {
+                return Some(format!(
+                    "Calling unsafe function '{}' in switch condition at line {} requires unsafe context",
+                    unsafe_func, location.line
+                ));
+            }
+
+            for case in cases {
+                let case_errors = check_statements_with_unsafe_tracking(
+                    &case.statements,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                    0,
+                );
+                if !case_errors.is_empty() {
+                    return Some(case_errors.into_iter().next().unwrap());
                 }
             }
         }

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -224,7 +224,35 @@ fn collect_lambda_body_unsafe_errors_in_expression(
     let mut errors = Vec::new();
 
     match expr {
-        Expression::Lambda { body, .. } => {
+        Expression::Lambda {
+            capture_initializers,
+            body,
+            ..
+        } => {
+            for initializer in capture_initializers {
+                if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                    initializer,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ) {
+                    errors.push(format!(
+                        "In lambda capture initializer: Calling unsafe function '{}' requires unsafe context",
+                        unsafe_func
+                    ));
+                }
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    initializer,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+            }
+
             for error in check_statements_with_unsafe_tracking(
                 body,
                 safety_context,

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -282,8 +282,7 @@ fn collect_lambda_body_unsafe_errors_in_expression(
         | Expression::Cast { inner, .. }
         | Expression::MemberAccess { object: inner, .. }
         | Expression::New(inner)
-        | Expression::Delete(inner)
-        | Expression::PointerArithmetic { pointer: inner, .. } => {
+        | Expression::Delete(inner) => {
             errors.extend(collect_lambda_body_unsafe_errors_in_expression(
                 inner,
                 safety_context,
@@ -292,6 +291,28 @@ fn collect_lambda_body_unsafe_errors_in_expression(
                 template_params,
                 callable_params,
             ));
+        }
+        Expression::PointerArithmetic {
+            pointer, offset, ..
+        } => {
+            errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                pointer,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ));
+            if let Some(offset) = offset {
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    offset,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+            }
         }
         Expression::ArraySubscript { array, index } => {
             errors.extend(collect_lambda_body_unsafe_errors_in_expression(
@@ -965,6 +986,28 @@ fn find_unsafe_function_call_with_external(
                 return Some(unsafe_func);
             }
         }
+        Expression::ArraySubscript { array, index } => {
+            if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                array,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ) {
+                return Some(unsafe_func);
+            }
+            if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                index,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ) {
+                return Some(unsafe_func);
+            }
+        }
         Expression::Move { inner, .. }
         | Expression::Dereference(inner)
         | Expression::AddressOf(inner)
@@ -980,6 +1023,32 @@ fn find_unsafe_function_call_with_external(
                 callable_params,
             ) {
                 return Some(unsafe_func);
+            }
+        }
+        Expression::PointerArithmetic {
+            pointer, offset, ..
+        } => {
+            if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                pointer,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ) {
+                return Some(unsafe_func);
+            }
+            if let Some(offset) = offset {
+                if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                    offset,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ) {
+                    return Some(unsafe_func);
+                }
             }
         }
         _ => {}

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -22,6 +22,22 @@ pub fn check_unsafe_propagation_with_external(
     let callable_params =
         get_callable_parameters(&function.parameters, &function.template_parameters);
 
+    for initializer in &function.member_initializers {
+        if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+            &initializer.initializer,
+            safety_context,
+            known_safe_functions,
+            external_annotations,
+            &function.template_parameters,
+            &callable_params,
+        ) {
+            errors.push(format!(
+                "In function '{}': Calling unsafe function '{}' in constructor initializer for '{}' at line {} requires unsafe context",
+                function.name, unsafe_func, initializer.member_name, initializer.location.line
+            ));
+        }
+    }
+
     for error in check_statements_with_unsafe_tracking(
         &function.body,
         safety_context,

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -23,6 +23,19 @@ pub fn check_unsafe_propagation_with_external(
         get_callable_parameters(&function.parameters, &function.template_parameters);
 
     for initializer in &function.member_initializers {
+        errors.extend(
+            collect_lambda_body_unsafe_errors_in_expression(
+                &initializer.initializer,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                &function.template_parameters,
+                &callable_params,
+            )
+            .into_iter()
+            .map(|error| format!("In function '{}': {}", function.name, error)),
+        );
+
         if let Some(unsafe_func) = find_unsafe_function_call_with_external(
             &initializer.initializer,
             safety_context,
@@ -38,6 +51,19 @@ pub fn check_unsafe_propagation_with_external(
         }
     }
 
+    errors.extend(
+        collect_lambda_body_unsafe_errors_in_statements(
+            &function.body,
+            safety_context,
+            known_safe_functions,
+            external_annotations,
+            &function.template_parameters,
+            &callable_params,
+        )
+        .into_iter()
+        .map(|error| format!("In function '{}': {}", function.name, error)),
+    );
+
     for error in check_statements_with_unsafe_tracking(
         &function.body,
         safety_context,
@@ -48,6 +74,244 @@ pub fn check_unsafe_propagation_with_external(
         0,
     ) {
         errors.push(format!("In function '{}': {}", function.name, error));
+    }
+
+    errors
+}
+
+fn collect_lambda_body_unsafe_errors_in_statements(
+    statements: &[Statement],
+    safety_context: &SafetyContext,
+    known_safe_functions: &HashSet<String>,
+    external_annotations: Option<&ExternalAnnotations>,
+    template_params: &[String],
+    callable_params: &HashSet<String>,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    for stmt in statements {
+        match stmt {
+            Statement::Assignment { lhs, rhs, .. } => {
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    lhs,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    rhs,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+            }
+            Statement::ReferenceBinding { target, .. } => {
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    target,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+            }
+            Statement::Return(Some(expr)) | Statement::ExpressionStatement { expr, .. } => {
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    expr,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+            }
+            Statement::FunctionCall { args, .. } => {
+                for arg in args {
+                    errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                        arg,
+                        safety_context,
+                        known_safe_functions,
+                        external_annotations,
+                        template_params,
+                        callable_params,
+                    ));
+                }
+            }
+            Statement::If {
+                condition,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    condition,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+                errors.extend(collect_lambda_body_unsafe_errors_in_statements(
+                    then_branch,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+                if let Some(else_branch) = else_branch {
+                    errors.extend(collect_lambda_body_unsafe_errors_in_statements(
+                        else_branch,
+                        safety_context,
+                        known_safe_functions,
+                        external_annotations,
+                        template_params,
+                        callable_params,
+                    ));
+                }
+            }
+            Statement::Switch {
+                condition, cases, ..
+            } => {
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    condition,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+                for case in cases {
+                    errors.extend(collect_lambda_body_unsafe_errors_in_statements(
+                        &case.statements,
+                        safety_context,
+                        known_safe_functions,
+                        external_annotations,
+                        template_params,
+                        callable_params,
+                    ));
+                }
+            }
+            Statement::Block(inner) => {
+                errors.extend(collect_lambda_body_unsafe_errors_in_statements(
+                    inner,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    errors
+}
+
+fn collect_lambda_body_unsafe_errors_in_expression(
+    expr: &Expression,
+    safety_context: &SafetyContext,
+    known_safe_functions: &HashSet<String>,
+    external_annotations: Option<&ExternalAnnotations>,
+    template_params: &[String],
+    callable_params: &HashSet<String>,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    match expr {
+        Expression::Lambda { body, .. } => {
+            for error in check_statements_with_unsafe_tracking(
+                body,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+                0,
+            ) {
+                errors.push(format!("In lambda body: {}", error));
+            }
+
+            errors.extend(collect_lambda_body_unsafe_errors_in_statements(
+                body,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ));
+        }
+        Expression::FunctionCall { args, .. } => {
+            for arg in args {
+                errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                    arg,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ));
+            }
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                left,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ));
+            errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                right,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ));
+        }
+        Expression::Move { inner, .. }
+        | Expression::Dereference(inner)
+        | Expression::AddressOf(inner)
+        | Expression::Cast { inner, .. }
+        | Expression::MemberAccess { object: inner, .. }
+        | Expression::New(inner)
+        | Expression::Delete(inner)
+        | Expression::PointerArithmetic { pointer: inner, .. } => {
+            errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                inner,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ));
+        }
+        Expression::ArraySubscript { array, index } => {
+            errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                array,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ));
+            errors.extend(collect_lambda_body_unsafe_errors_in_expression(
+                index,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ));
+        }
+        _ => {}
     }
 
     errors

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -285,7 +285,11 @@ fn check_statement_for_unsafe_calls_with_external(
     }
 
     match stmt {
-        Statement::FunctionCall { name, location, .. } => {
+        Statement::FunctionCall {
+            name,
+            args,
+            location,
+        } => {
             // Check if this is a template type parameter (not a real function call)
             // Phase 1: Enhanced check for variadic pack parameters
             if is_template_parameter_like(name, template_params) {
@@ -347,6 +351,22 @@ fn check_statement_for_unsafe_calls_with_external(
                     return Some(format!(
                         "Calling non-safe function '{}' at line {} requires @unsafe {{ }} block",
                         name, location.line
+                    ));
+                }
+            }
+
+            for arg in args {
+                if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                    arg,
+                    safety_context,
+                    known_safe_functions,
+                    external_annotations,
+                    template_params,
+                    callable_params,
+                ) {
+                    return Some(format!(
+                        "Calling unsafe function '{}' in argument at line {} requires unsafe context",
+                        unsafe_func, location.line
                     ));
                 }
             }

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -688,7 +688,8 @@ fn find_unsafe_function_call_with_external(
         Expression::Move { inner, .. }
         | Expression::Dereference(inner)
         | Expression::AddressOf(inner)
-        | Expression::Cast { inner, .. } => {
+        | Expression::Cast { inner, .. }
+        | Expression::MemberAccess { object: inner, .. } => {
             // Check inner expression
             if let Some(unsafe_func) = find_unsafe_function_call_with_external(
                 inner,

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -1012,7 +1012,9 @@ fn find_unsafe_function_call_with_external(
         | Expression::Dereference(inner)
         | Expression::AddressOf(inner)
         | Expression::Cast { inner, .. }
-        | Expression::MemberAccess { object: inner, .. } => {
+        | Expression::MemberAccess { object: inner, .. }
+        | Expression::New(inner)
+        | Expression::Delete(inner) => {
             // Check inner expression
             if let Some(unsafe_func) = find_unsafe_function_call_with_external(
                 inner,

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -383,6 +383,21 @@ fn check_statement_for_unsafe_calls_with_external(
                 ));
             }
         }
+        Statement::ExpressionStatement { expr, location } => {
+            if let Some(unsafe_func) = find_unsafe_function_call_with_external(
+                expr,
+                safety_context,
+                known_safe_functions,
+                external_annotations,
+                template_params,
+                callable_params,
+            ) {
+                return Some(format!(
+                    "Calling unsafe function '{}' in expression at line {} requires unsafe context",
+                    unsafe_func, location.line
+                ));
+            }
+        }
         Statement::If {
             condition,
             then_branch,

--- a/src/analysis/unsafe_propagation.rs
+++ b/src/analysis/unsafe_propagation.rs
@@ -687,7 +687,8 @@ fn find_unsafe_function_call_with_external(
         }
         Expression::Move { inner, .. }
         | Expression::Dereference(inner)
-        | Expression::AddressOf(inner) => {
+        | Expression::AddressOf(inner)
+        | Expression::Cast { inner, .. } => {
             // Check inner expression
             if let Some(unsafe_func) = find_unsafe_function_call_with_external(
                 inner,

--- a/src/annotator.rs
+++ b/src/annotator.rs
@@ -1,0 +1,253 @@
+use crate::parser;
+use regex::Regex;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Default)]
+pub struct AnnotationSummary {
+    pub safe_count: usize,
+    pub unsafe_count: usize,
+    pub skipped_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct CandidateFunction {
+    name: String,
+    line: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnnotationMode {
+    Safe,
+    Unsafe,
+}
+
+impl AnnotationMode {
+    fn as_comment(self) -> &'static str {
+        match self {
+            AnnotationMode::Safe => "// @safe",
+            AnnotationMode::Unsafe => "// @unsafe",
+        }
+    }
+}
+
+pub fn annotate_file(
+    path: &PathBuf,
+    include_paths: &[PathBuf],
+    defines: &[String],
+    compile_commands: Option<&PathBuf>,
+) -> Result<AnnotationSummary, String> {
+    let candidates = collect_candidates(path, include_paths, defines, compile_commands)?;
+    if candidates.functions.is_empty() {
+        return Ok(AnnotationSummary {
+            skipped_count: candidates.skipped_count,
+            ..AnnotationSummary::default()
+        });
+    }
+
+    let mut modes = candidates
+        .functions
+        .iter()
+        .map(|function| (function.line, AnnotationMode::Safe))
+        .collect::<BTreeMap<_, _>>();
+    let candidate_names = candidates
+        .functions
+        .iter()
+        .map(|function| function.name.clone())
+        .collect::<HashSet<_>>();
+
+    loop {
+        let temp_path = write_annotated_temp_file(path, &candidates.original_lines, &modes)?;
+        let analysis_result =
+            crate::analyze_file(&temp_path, include_paths, defines, compile_commands);
+        let _ = fs::remove_file(&temp_path);
+
+        let violations = analysis_result?;
+        let violating_names = extract_violating_function_names(&violations, &candidate_names);
+        let mut changed = false;
+
+        for function in &candidates.functions {
+            if violating_names.contains(&function.name)
+                && modes.get(&function.line) != Some(&AnnotationMode::Unsafe)
+            {
+                modes.insert(function.line, AnnotationMode::Unsafe);
+                changed = true;
+            }
+        }
+
+        if !changed {
+            break;
+        }
+    }
+
+    let final_source = render_with_annotations(&candidates.original_lines, &modes);
+    fs::write(path, final_source)
+        .map_err(|e| format!("Failed to write annotations to {}: {}", path.display(), e))?;
+
+    let safe_count = modes
+        .values()
+        .filter(|&&mode| mode == AnnotationMode::Safe)
+        .count();
+    let unsafe_count = modes.len() - safe_count;
+
+    Ok(AnnotationSummary {
+        safe_count,
+        unsafe_count,
+        skipped_count: candidates.skipped_count,
+    })
+}
+
+struct CandidateCollection {
+    original_lines: Vec<String>,
+    functions: Vec<CandidateFunction>,
+    skipped_count: usize,
+}
+
+fn collect_candidates(
+    path: &PathBuf,
+    include_paths: &[PathBuf],
+    defines: &[String],
+    compile_commands: Option<&PathBuf>,
+) -> Result<CandidateCollection, String> {
+    let analysis_config = crate::build_analysis_config(path, include_paths, compile_commands)?;
+    let ast = parser::parse_cpp_file_with_includes_defines_and_args(
+        path,
+        &analysis_config.include_paths,
+        defines,
+        &analysis_config.extra_clang_args,
+    )?;
+    let canonical_path = fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+    let original = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    let original_lines = original
+        .lines()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+
+    let mut functions = Vec::new();
+    let mut skipped_count = 0usize;
+    let mut seen_lines = BTreeSet::new();
+
+    let parsed_functions = ast
+        .functions
+        .iter()
+        .chain(ast.classes.iter().flat_map(|class| class.methods.iter()));
+
+    for function in parsed_functions {
+        let fn_path = fs::canonicalize(&function.location.file)
+            .unwrap_or_else(|_| PathBuf::from(&function.location.file));
+        if fn_path != canonical_path {
+            continue;
+        }
+
+        if function.has_explicit_safety_annotation {
+            skipped_count += 1;
+            continue;
+        }
+
+        let line = function.location.line as usize;
+        if line == 0 || line > original_lines.len() {
+            continue;
+        }
+
+        if has_existing_annotation(&original_lines, line) {
+            skipped_count += 1;
+            continue;
+        }
+
+        if seen_lines.insert(line) {
+            functions.push(CandidateFunction {
+                name: function.name.clone(),
+                line,
+            });
+        }
+    }
+
+    functions.sort_by_key(|function| function.line);
+
+    Ok(CandidateCollection {
+        original_lines,
+        functions,
+        skipped_count,
+    })
+}
+
+fn has_existing_annotation(lines: &[String], one_based_line: usize) -> bool {
+    let mut idx = one_based_line.saturating_sub(1);
+    while idx > 0 {
+        idx -= 1;
+        let trimmed = lines[idx].trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        return is_safety_annotation(trimmed);
+    }
+    false
+}
+
+fn is_safety_annotation(line: &str) -> bool {
+    line.starts_with("// @safe") || line.starts_with("// @unsafe") || line.starts_with("// @bridge")
+}
+
+fn write_annotated_temp_file(
+    original_path: &Path,
+    lines: &[String],
+    modes: &BTreeMap<usize, AnnotationMode>,
+) -> Result<PathBuf, String> {
+    let file_name = original_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("source.cpp");
+    let temp_path = original_path.with_file_name(format!(".{}.rusty-annotator.tmp.cpp", file_name));
+    fs::write(&temp_path, render_with_annotations(lines, modes)).map_err(|e| {
+        format!(
+            "Failed to write temporary annotated file {}: {}",
+            temp_path.display(),
+            e
+        )
+    })?;
+    Ok(temp_path)
+}
+
+fn render_with_annotations(lines: &[String], modes: &BTreeMap<usize, AnnotationMode>) -> String {
+    let mut rendered = String::new();
+    for (idx, line) in lines.iter().enumerate() {
+        let one_based_line = idx + 1;
+        if let Some(mode) = modes.get(&one_based_line) {
+            rendered.push_str(mode.as_comment());
+            rendered.push('\n');
+        }
+        rendered.push_str(line);
+        rendered.push('\n');
+    }
+    rendered
+}
+
+fn extract_violating_function_names(
+    violations: &[String],
+    candidate_names: &HashSet<String>,
+) -> HashSet<String> {
+    let re = Regex::new(r"In function '([^']+)'").expect("valid function diagnostic regex");
+    let mut names = HashSet::new();
+
+    for violation in violations {
+        for captures in re.captures_iter(violation) {
+            if let Some(name) = captures.get(1).map(|m| m.as_str()) {
+                if candidate_names.contains(name) {
+                    names.insert(name.to_string());
+                    continue;
+                }
+
+                if let Some(candidate_name) = candidate_names.iter().find(|candidate| {
+                    candidate.ends_with(&format!("::{}", name))
+                        || name.ends_with(&format!("::{}", candidate))
+                }) {
+                    names.insert(candidate_name.clone());
+                }
+            }
+        }
+    }
+
+    names
+}

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1800,7 +1800,7 @@ fn convert_statement(
                     }]))
                 }
                 // Lambda expression: generate LambdaCapture statement for safety checking
-                crate::parser::Expression::Lambda { captures } => {
+                crate::parser::Expression::Lambda { captures, .. } => {
                     debug_println!("DEBUG IR: Lambda assignment: {} = [captures]", lhs_var);
                     let capture_infos: Vec<LambdaCaptureInfo> = captures
                         .iter()

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -348,6 +348,9 @@ pub enum IrStatement {
         then_branch: Vec<IrStatement>,
         else_branch: Option<Vec<IrStatement>>,
     },
+    Switch {
+        cases: Vec<Vec<IrStatement>>,
+    },
     // Safety markers
     EnterUnsafe,
     ExitUnsafe,
@@ -708,6 +711,7 @@ fn get_statement_line(stmt: &crate::parser::Statement) -> Option<u32> {
         Statement::ReferenceBinding { location, .. } => Some(location.line),
         Statement::FunctionCall { location, .. } => Some(location.line),
         Statement::If { location, .. } => Some(location.line),
+        Statement::Switch { location, .. } => Some(location.line),
         Statement::ExpressionStatement { location, .. } => Some(location.line),
         _ => None,
     }
@@ -960,6 +964,10 @@ fn convert_statement(
             Statement::If { condition, .. } => {
                 debug_println!("DEBUG IR:   If condition: {:?}", condition);
                 "If"
+            }
+            Statement::Switch { condition, .. } => {
+                debug_println!("DEBUG IR:   Switch condition: {:?}", condition);
+                "Switch"
             }
             _ => "Other",
         }
@@ -2393,6 +2401,56 @@ fn convert_statement(
                 then_branch: then_ir,
                 else_branch: else_ir,
             });
+            Ok(Some(result))
+        }
+        Statement::Switch {
+            condition, cases, ..
+        } => {
+            let mut condition_ir = Vec::new();
+
+            match condition {
+                crate::parser::Expression::FunctionCall { name, args } => {
+                    let is_method_call = name.contains("::") || name.starts_with("operator");
+
+                    for (i, arg) in args.iter().enumerate() {
+                        if let crate::parser::Expression::Variable(var) = arg {
+                            if is_method_call && i == 0 {
+                                condition_ir.push(IrStatement::UseVariable {
+                                    var: var.clone(),
+                                    operation: format!("call method '{}' in switch condition", name),
+                                });
+                            }
+                        }
+                    }
+                }
+                crate::parser::Expression::Variable(var) => {
+                    condition_ir.push(IrStatement::UseVariable {
+                        var: var.clone(),
+                        operation: "use in switch condition".to_string(),
+                    });
+                }
+                _ => {}
+            }
+
+            let mut case_ir = Vec::new();
+            for case in cases {
+                let mut statements = Vec::new();
+                for stmt in &case.statements {
+                    if let Some(ir_stmts) = convert_statement(
+                        stmt,
+                        variables,
+                        current_scope_level,
+                        user_defined_raii_types,
+                        types_with_ref_members,
+                    )? {
+                        statements.extend(ir_stmts);
+                    }
+                }
+                case_ir.push(statements);
+            }
+
+            let mut result = condition_ir;
+            result.push(IrStatement::Switch { cases: case_ir });
             Ok(Some(result))
         }
         Statement::ExpressionStatement { expr, .. } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 mod debug_macros;
 
 mod analysis;
+mod annotator;
 mod diagnostics;
 mod ir;
 mod parser;
@@ -52,6 +53,10 @@ struct Args {
     /// Output format (text, json)
     #[arg(long, default_value = "text")]
     format: String,
+
+    /// Edit the input file by inserting // @safe or // @unsafe above unannotated functions
+    #[arg(long)]
+    annotate_safety: bool,
 }
 
 #[derive(Debug, Default)]
@@ -64,10 +69,42 @@ struct CompileCommandConfig {
     compiler_path: Option<PathBuf>,
 }
 
+#[derive(Debug, Default)]
+struct AnalysisConfig {
+    include_paths: Vec<PathBuf>,
+    extra_clang_args: Vec<String>,
+}
+
 fn main() {
     let args = Args::parse();
 
     println!("{}", "Rusty C++ Checker".bold().blue());
+    if args.annotate_safety {
+        println!("Annotating: {}", args.input.display());
+        match annotator::annotate_file(
+            &args.input,
+            &args.include_paths,
+            &args.defines,
+            args.compile_commands.as_ref(),
+        ) {
+            Ok(summary) => {
+                println!(
+                    "{}",
+                    format!(
+                        "✓ Annotated {} safe function(s), {} unsafe function(s); skipped {} already annotated function(s).",
+                        summary.safe_count, summary.unsafe_count, summary.skipped_count
+                    )
+                    .green()
+                );
+            }
+            Err(e) => {
+                eprintln!("{}: {}", "Error".red().bold(), e);
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
     println!("Analyzing: {}", args.input.display());
 
     match analyze_file(
@@ -108,60 +145,9 @@ fn analyze_file(
     defines: &[String],
     compile_commands: Option<&PathBuf>,
 ) -> Result<Vec<String>, String> {
-    // Start with CLI-provided include paths
-    let mut all_include_paths = include_paths.to_vec();
-    let mut extra_clang_args: Vec<String> = Vec::new();
-    let mut should_auto_detect_clang_includes = true;
-
-    // Add include paths from environment variables
-    all_include_paths.extend(extract_include_paths_from_env());
-
-    // Extract additional include paths and compile flags from compile_commands.json if provided
-    let mut cc_compiler_path: Option<PathBuf> = None;
-    if let Some(cc_path) = compile_commands {
-        let extracted = extract_compile_config_from_compile_commands(cc_path, path)?;
-        // For module/libc++ builds we should trust compile_commands include paths.
-        // Injecting auto-detected STL paths can mix libstdc++ and libc++ and produce
-        // ambiguous declarations that break parsing.
-        should_auto_detect_clang_includes = !extracted.clang_args.iter().any(|arg| {
-            arg == "-stdlib"
-                || arg.starts_with("-stdlib=")
-                || arg == "-fmodules"
-                || arg == "-fmodules-ts"
-                || arg.starts_with("-fmodule-file=")
-                || arg.starts_with("-fmodule-map-file=")
-                || arg.starts_with("-fprebuilt-module-path=")
-        });
-        all_include_paths.extend(extracted.include_paths);
-        extra_clang_args.extend(extracted.clang_args);
-        cc_compiler_path = extracted.compiler_path;
-    }
-
-    // Auto-detect C++ standard library paths from clang installation when needed.
-    if should_auto_detect_clang_includes {
-        all_include_paths.extend(extract_include_paths_from_clang());
-    } else {
-        // Even when compile_commands.json owns the STL paths (libc++ / module
-        // builds), libclang needs to know where its builtin resource directory
-        // lives (for `stddef.h`, `stdarg.h`, intrinsics, etc.) so the
-        // wrapper-header dance with libc++ works. Use `-resource-dir=...`
-        // rather than `-I<resource-dir>/include` — passing the dir as a
-        // regular `-I` puts it ahead of libc++ on the search path and breaks
-        // `__has_include_next` patterns in libc++'s wrappers. With
-        // `-resource-dir=`, libclang slots the builtin headers into the
-        // canonical `-isystem` position and the libc++ wrappers resolve
-        // correctly.
-        //
-        // CRITICAL: the resource dir MUST come from the SAME toolchain that
-        // produced the PCM/BMI files in compile_commands.json. Mismatched
-        // resource dirs (e.g. clang-19 + libclang-22 + clang-22 BMIs) crash
-        // libclang during BMI deserialization. We pass the compile_commands
-        // compiler down so the resolver can query `-print-resource-dir`
-        // from that specific binary.
-        if let Some(dir) = find_libclang_resource_root_for(cc_compiler_path.as_deref()) {
-            extra_clang_args.push(format!("-resource-dir={}", dir.display()));
-        }
-    }
+    let analysis_config = build_analysis_config(path, include_paths, compile_commands)?;
+    let all_include_paths = analysis_config.include_paths;
+    let extra_clang_args = analysis_config.extra_clang_args;
 
     // Parse included headers for lifetime annotations
     let mut header_cache = parser::HeaderCache::new();
@@ -464,6 +450,72 @@ fn analyze_file(
     violations.extend(borrow_violations);
 
     Ok(violations)
+}
+
+fn build_analysis_config(
+    path: &PathBuf,
+    include_paths: &[PathBuf],
+    compile_commands: Option<&PathBuf>,
+) -> Result<AnalysisConfig, String> {
+    // Start with CLI-provided include paths
+    let mut all_include_paths = include_paths.to_vec();
+    let mut extra_clang_args: Vec<String> = Vec::new();
+    let mut should_auto_detect_clang_includes = true;
+
+    // Add include paths from environment variables
+    all_include_paths.extend(extract_include_paths_from_env());
+
+    // Extract additional include paths and compile flags from compile_commands.json if provided
+    let mut cc_compiler_path: Option<PathBuf> = None;
+    if let Some(cc_path) = compile_commands {
+        let extracted = extract_compile_config_from_compile_commands(cc_path, path)?;
+        // For module/libc++ builds we should trust compile_commands include paths.
+        // Injecting auto-detected STL paths can mix libstdc++ and libc++ and produce
+        // ambiguous declarations that break parsing.
+        should_auto_detect_clang_includes = !extracted.clang_args.iter().any(|arg| {
+            arg == "-stdlib"
+                || arg.starts_with("-stdlib=")
+                || arg == "-fmodules"
+                || arg == "-fmodules-ts"
+                || arg.starts_with("-fmodule-file=")
+                || arg.starts_with("-fmodule-map-file=")
+                || arg.starts_with("-fprebuilt-module-path=")
+        });
+        all_include_paths.extend(extracted.include_paths);
+        extra_clang_args.extend(extracted.clang_args);
+        cc_compiler_path = extracted.compiler_path;
+    }
+
+    // Auto-detect C++ standard library paths from clang installation when needed.
+    if should_auto_detect_clang_includes {
+        all_include_paths.extend(extract_include_paths_from_clang());
+    } else {
+        // Even when compile_commands.json owns the STL paths (libc++ / module
+        // builds), libclang needs to know where its builtin resource directory
+        // lives (for `stddef.h`, `stdarg.h`, intrinsics, etc.) so the
+        // wrapper-header dance with libc++ works. Use `-resource-dir=...`
+        // rather than `-I<resource-dir>/include` — passing the dir as a
+        // regular `-I` puts it ahead of libc++ on the search path and breaks
+        // `__has_include_next` patterns in libc++'s wrappers. With
+        // `-resource-dir=`, libclang slots the builtin headers into the
+        // canonical `-isystem` position and the libc++ wrappers resolve
+        // correctly.
+        //
+        // CRITICAL: the resource dir MUST come from the SAME toolchain that
+        // produced the PCM/BMI files in compile_commands.json. Mismatched
+        // resource dirs (e.g. clang-19 + libclang-22 + clang-22 BMIs) crash
+        // libclang during BMI deserialization. We pass the compile_commands
+        // compiler down so the resolver can query `-print-resource-dir`
+        // from that specific binary.
+        if let Some(dir) = find_libclang_resource_root_for(cc_compiler_path.as_deref()) {
+            extra_clang_args.push(format!("-resource-dir={}", dir.display()));
+        }
+    }
+
+    Ok(AnalysisConfig {
+        include_paths: all_include_paths,
+        extra_clang_args,
+    })
 }
 
 fn extract_compile_config_from_compile_commands(

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,16 @@ fn analyze_file(
 
     // Check for unsafe pointer operations and unsafe propagation in safe functions
     let mut violations = Vec::new();
-    debug_println!("DEBUG: Found {} functions in AST", ast.functions.len());
+    let parsed_functions: Vec<_> = ast
+        .functions
+        .iter()
+        .chain(ast.classes.iter().flat_map(|class| class.methods.iter()))
+        .collect();
+
+    debug_println!(
+        "DEBUG: Found {} functions/methods in AST",
+        parsed_functions.len()
+    );
 
     // Canonical path of the file being checked. Used to filter out function
     // bodies that libclang surfaced via imports/headers — those should be
@@ -271,7 +280,7 @@ fn analyze_file(
     // re-flags every @safe→@unsafe call in Reactor's methods).
     let main_file_canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
 
-    for function in &ast.functions {
+    for function in parsed_functions {
         // Skip system header functions - they shouldn't be analyzed internally
         if is_system_header_or_std(&function.location.file, &function.name) {
             debug_println!(

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -3571,6 +3571,27 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
             }
             None
         }
+        EntityKind::ConditionalOperator => {
+            let children: Vec<Entity> = entity.get_children().into_iter().collect();
+            if children.len() == 3 {
+                if let (Some(condition), Some(true_expr), Some(false_expr)) = (
+                    extract_expression(&children[0]),
+                    extract_expression(&children[1]),
+                    extract_expression(&children[2]),
+                ) {
+                    return Some(Expression::BinaryOp {
+                        left: Box::new(condition),
+                        op: "?:".to_string(),
+                        right: Box::new(Expression::BinaryOp {
+                            left: Box::new(true_expr),
+                            op: ":".to_string(),
+                            right: Box::new(false_expr),
+                        }),
+                    });
+                }
+            }
+            None
+        }
         EntityKind::IntegerLiteral => {
             // IntegerLiterals often have name=None, try display_name or tokens
             if let Some(name) = entity.get_name() {
@@ -3582,6 +3603,15 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                 // need the actual value for ownership/borrow checking
                 Some(Expression::Literal("0".to_string()))
             }
+        }
+        EntityKind::BoolLiteralExpr => {
+            if let Some(range) = entity.get_range() {
+                let tokens = safe_tokenize(&range);
+                if let Some(token) = tokens.first() {
+                    return Some(Expression::Literal(token.get_spelling()));
+                }
+            }
+            Some(Expression::Literal("bool".to_string()))
         }
         EntityKind::StringLiteral => {
             // String literals ("hello", L"wide", u8"utf8", etc.) have static lifetime

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -450,7 +450,9 @@ pub enum MethodQualifier {
 #[derive(Debug, Clone)]
 pub struct MemberInitializer {
     pub member_name: String,
+    pub initializer: Expression,
     pub is_nullptr: bool, // Quick check if initialized to nullptr
+    pub location: SourceLocation,
 }
 
 #[derive(Debug, Clone)]
@@ -721,18 +723,26 @@ fn extract_member_initializers(entity: &Entity) -> Vec<MemberInitializer> {
             let member_name = child.get_name().unwrap_or_default();
 
             // Get the next sibling as the initialization expression
-            let init_expr = if i + 1 < children.len() {
+            let (init_expr, init_location) = if i + 1 < children.len() {
                 let next = &children[i + 1];
                 let next_kind = next.get_kind();
                 // Skip if next is another MemberRef or the body - means no initializer
                 if next_kind != EntityKind::MemberRef && next_kind != EntityKind::CompoundStmt {
                     i += 1; // Consume the expression
-                    extract_expression_from_entity(next)
+                    let expr = extract_expression(next)
+                        .unwrap_or_else(|| extract_expression_from_entity(next));
+                    (expr, extract_location(next))
                 } else {
-                    Expression::Literal("unknown".to_string())
+                    (
+                        Expression::Literal("unknown".to_string()),
+                        extract_location(child),
+                    )
                 }
             } else {
-                Expression::Literal("unknown".to_string())
+                (
+                    Expression::Literal("unknown".to_string()),
+                    extract_location(child),
+                )
             };
 
             // Check if the initializer is nullptr
@@ -744,7 +754,9 @@ fn extract_member_initializers(entity: &Entity) -> Vec<MemberInitializer> {
 
             initializers.push(MemberInitializer {
                 member_name,
+                initializer: init_expr,
                 is_nullptr,
+                location: init_location,
             });
         }
 

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -2331,6 +2331,15 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                     });
                 }
             }
+            EntityKind::ThrowExpr => {
+                // Handle throw expressions so unsafe operands are still checked.
+                if let Some(expr) = extract_expression(&child) {
+                    statements.push(Statement::ExpressionStatement {
+                        expr,
+                        location: extract_location(&child),
+                    });
+                }
+            }
             EntityKind::PackExpansionExpr => {
                 // Handle pack expansion at statement level (direct fold expressions)
                 if let Some(pack_stmt) = extract_pack_expansion(&child) {
@@ -2884,7 +2893,8 @@ fn extract_single_statement(entity: &Entity) -> Vec<Statement> {
         EntityKind::UnexposedExpr
         | EntityKind::UnaryOperator
         | EntityKind::NewExpr
-        | EntityKind::DeleteExpr => {
+        | EntityKind::DeleteExpr
+        | EntityKind::ThrowExpr => {
             if let Some(expr) = extract_expression(entity) {
                 vec![Statement::ExpressionStatement { expr, location }]
             } else {
@@ -4215,6 +4225,10 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                 "ptr".to_string(),
             ))))
         }
+        EntityKind::ThrowExpr => entity
+            .get_children()
+            .into_iter()
+            .find_map(|child| extract_expression(&child)),
         _ => None,
     }
 }

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -2184,6 +2184,21 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
 
                 statements.push(Statement::ExitScope);
             }
+            EntityKind::ForRangeStmt => {
+                statements.extend(extract_range_for_control_statements(&child));
+                statements.push(Statement::EnterLoop);
+
+                let loop_children: Vec<Entity> = child.get_children().into_iter().collect();
+                if let Some(loop_body) = loop_children.last() {
+                    if loop_body.get_kind() == EntityKind::CompoundStmt {
+                        statements.extend(extract_compound_statement(loop_body));
+                    } else {
+                        statements.extend(extract_single_statement(loop_body));
+                    }
+                }
+
+                statements.push(Statement::ExitLoop);
+            }
             EntityKind::ForStmt | EntityKind::WhileStmt | EntityKind::DoStmt => {
                 statements.push(Statement::EnterLoop);
 
@@ -2370,6 +2385,271 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
     }
 
     statements
+}
+
+fn extract_range_for_control_statements(entity: &Entity) -> Vec<Statement> {
+    let mut statements = Vec::new();
+
+    // Clang exposes C++ range-for roughly as:
+    //   null, DeclStmt(__range = <user range expr>), DeclStmt(__begin),
+    //   DeclStmt(__end), condition, increment, DeclStmt(loop var), body.
+    // Only the __range initializer came from the user's range expression.
+    // The begin/end/iterator pieces are compiler desugaring and should not
+    // make ordinary range-for syntax look unsafe.
+    for child in entity.get_children() {
+        if child.get_kind() != EntityKind::DeclStmt {
+            continue;
+        }
+
+        for decl_child in child.get_children() {
+            if decl_child.get_kind() != EntityKind::VarDecl {
+                continue;
+            }
+
+            let name = decl_child.get_name().unwrap_or_default();
+            if !name.starts_with("__range") {
+                continue;
+            }
+
+            for init_child in decl_child.get_children() {
+                if let Some(expr) = extract_expression(&init_child) {
+                    let location = extract_location(&init_child);
+                    statements.push(expression_to_statement(expr, location));
+                    return statements;
+                }
+            }
+        }
+    }
+
+    if let Some(stmt) = extract_range_for_expression_from_tokens(entity) {
+        statements.push(stmt);
+    }
+
+    statements
+}
+
+fn expression_to_statement(expr: Expression, location: SourceLocation) -> Statement {
+    match expr {
+        Expression::FunctionCall { name, args } => Statement::FunctionCall {
+            name,
+            args,
+            location,
+        },
+        expr => Statement::ExpressionStatement { expr, location },
+    }
+}
+
+fn extract_range_for_expression_from_tokens(entity: &Entity) -> Option<Statement> {
+    let range = entity.get_range()?;
+    let tokens = safe_tokenize(&range);
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let mut colon_idx = None;
+    let mut paren_depth = 0usize;
+
+    for (idx, token) in tokens.iter().enumerate() {
+        match token.get_spelling().as_str() {
+            "(" => paren_depth += 1,
+            ")" => paren_depth = paren_depth.saturating_sub(1),
+            ":" if paren_depth == 1 => {
+                colon_idx = Some(idx);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let colon_idx = colon_idx?;
+    let mut end_idx = tokens.len();
+    paren_depth = 1;
+
+    for (idx, token) in tokens.iter().enumerate().skip(colon_idx + 1) {
+        match token.get_spelling().as_str() {
+            "(" => paren_depth += 1,
+            ")" => {
+                paren_depth = paren_depth.saturating_sub(1);
+                if paren_depth == 0 {
+                    end_idx = idx;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if end_idx <= colon_idx + 1 {
+        return None;
+    }
+
+    let range_tokens: Vec<String> = tokens[colon_idx + 1..end_idx]
+        .iter()
+        .map(|token| token.get_spelling())
+        .collect();
+    let location = extract_location(entity);
+
+    extract_function_call_from_tokens(&range_tokens)
+        .map(|expr| expression_to_statement(expr, location.clone()))
+        .or_else(|| {
+            extract_variable_from_tokens(&range_tokens).map(|name| Statement::ExpressionStatement {
+                expr: Expression::Variable(name),
+                location,
+            })
+        })
+}
+
+fn extract_function_call_from_tokens(tokens: &[String]) -> Option<Expression> {
+    let mut idx = 0;
+    while idx + 1 < tokens.len() {
+        if tokens[idx + 1] == "(" && is_cpp_identifier(&tokens[idx]) {
+            let name = collect_qualified_name_before(tokens, idx);
+            if !name.is_empty() && !is_builtin_cast_name(&name) {
+                return Some(Expression::FunctionCall {
+                    name,
+                    args: Vec::new(),
+                });
+            }
+        }
+        idx += 1;
+    }
+
+    None
+}
+
+fn collect_qualified_name_before(tokens: &[String], name_idx: usize) -> String {
+    let mut parts = vec![tokens[name_idx].clone()];
+    let mut idx = name_idx;
+
+    while idx >= 2 && tokens[idx - 1] == "::" && is_cpp_identifier(&tokens[idx - 2]) {
+        parts.push(tokens[idx - 2].clone());
+        idx -= 2;
+    }
+
+    parts.reverse();
+    parts.join("::")
+}
+
+fn extract_variable_from_tokens(tokens: &[String]) -> Option<String> {
+    tokens
+        .iter()
+        .find(|token| is_cpp_identifier(token) && !is_cpp_keyword(token))
+        .cloned()
+}
+
+fn is_cpp_identifier(token: &str) -> bool {
+    let mut chars = token.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+fn is_cpp_keyword(token: &str) -> bool {
+    matches!(
+        token,
+        "alignas"
+            | "alignof"
+            | "and"
+            | "and_eq"
+            | "asm"
+            | "auto"
+            | "bitand"
+            | "bitor"
+            | "bool"
+            | "break"
+            | "case"
+            | "catch"
+            | "char"
+            | "char8_t"
+            | "char16_t"
+            | "char32_t"
+            | "class"
+            | "compl"
+            | "concept"
+            | "const"
+            | "consteval"
+            | "constexpr"
+            | "constinit"
+            | "const_cast"
+            | "continue"
+            | "co_await"
+            | "co_return"
+            | "co_yield"
+            | "decltype"
+            | "default"
+            | "delete"
+            | "do"
+            | "double"
+            | "dynamic_cast"
+            | "else"
+            | "enum"
+            | "explicit"
+            | "export"
+            | "extern"
+            | "false"
+            | "float"
+            | "for"
+            | "friend"
+            | "goto"
+            | "if"
+            | "inline"
+            | "int"
+            | "long"
+            | "mutable"
+            | "namespace"
+            | "new"
+            | "noexcept"
+            | "not"
+            | "not_eq"
+            | "nullptr"
+            | "operator"
+            | "or"
+            | "or_eq"
+            | "private"
+            | "protected"
+            | "public"
+            | "register"
+            | "reinterpret_cast"
+            | "requires"
+            | "return"
+            | "short"
+            | "signed"
+            | "sizeof"
+            | "static"
+            | "static_assert"
+            | "static_cast"
+            | "struct"
+            | "switch"
+            | "template"
+            | "this"
+            | "thread_local"
+            | "throw"
+            | "true"
+            | "try"
+            | "typedef"
+            | "typeid"
+            | "typename"
+            | "union"
+            | "unsigned"
+            | "using"
+            | "virtual"
+            | "void"
+            | "volatile"
+            | "wchar_t"
+            | "while"
+            | "xor"
+            | "xor_eq"
+    )
+}
+
+fn is_builtin_cast_name(name: &str) -> bool {
+    matches!(
+        name,
+        "static_cast" | "dynamic_cast" | "reinterpret_cast" | "const_cast"
+    )
 }
 
 fn extract_switch_statement(entity: &Entity) -> Statement {

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -649,6 +649,7 @@ pub enum Expression {
     // Lambda expression with captures
     Lambda {
         captures: Vec<LambdaCaptureKind>,
+        body: Vec<Statement>,
     },
     // C++ cast expression (static_cast, dynamic_cast, reinterpret_cast, const_cast, C-style)
     // Some casts are unsafe operations in @safe code
@@ -3840,6 +3841,7 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
             debug_println!("DEBUG LAMBDA PARSER: Found LambdaExpr!");
 
             let mut captures = Vec::new();
+            let mut body = Vec::new();
 
             // Collect all VariableRef entries (these are the captured variables)
             let mut var_refs: Vec<String> = Vec::new();
@@ -3857,6 +3859,9 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                     child.get_name()
                 );
                 match child.get_kind() {
+                    EntityKind::CompoundStmt => {
+                        body = extract_compound_statement(&child);
+                    }
                     EntityKind::VariableRef => {
                         has_explicit_captures = true;
                         if let Some(var_name) = child.get_name() {
@@ -4023,7 +4028,7 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                 captures
             );
 
-            Some(Expression::Lambda { captures })
+            Some(Expression::Lambda { captures, body })
         }
         EntityKind::ArraySubscriptExpr => {
             // Array subscript: arr[i], data[idx], ptr[n], etc.

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -672,6 +672,7 @@ pub enum Expression {
     PointerArithmetic {
         pointer: Box<Expression>,
         op: String,
+        offset: Option<Box<Expression>>,
     },
     /// Array subscript expression (arr[i], data[idx])
     /// Used for tracking array bounds checking
@@ -3559,6 +3560,7 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                             return Some(Expression::PointerArithmetic {
                                 pointer: Box::new(left),
                                 op: op.clone(),
+                                offset: Some(Box::new(right)),
                             });
                         }
                         // n + p (right is pointer, only for + operator)
@@ -3572,6 +3574,7 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                             return Some(Expression::PointerArithmetic {
                                 pointer: Box::new(right),
                                 op: op.clone(),
+                                offset: Some(Box::new(left)),
                             });
                         }
                         // p - q (pointer difference)
@@ -3584,6 +3587,7 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                             return Some(Expression::PointerArithmetic {
                                 pointer: Box::new(left),
                                 op: "pointer difference".to_string(),
+                                offset: Some(Box::new(right)),
                             });
                         }
                     }
@@ -3719,6 +3723,7 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                                 return Some(Expression::PointerArithmetic {
                                     pointer: Box::new(inner),
                                     op: "++/--".to_string(),
+                                    offset: None,
                                 });
                             }
                             // Otherwise, it's a non-pointer unary operator (!, ~, -, +)
@@ -4050,6 +4055,7 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                             return Some(Expression::PointerArithmetic {
                                 pointer: Box::new(array),
                                 op: "[]".to_string(),
+                                offset: Some(Box::new(index)),
                             });
                         }
                     }

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -1684,7 +1684,7 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                     }
                 }
             }
-            EntityKind::BinaryOperator => {
+            EntityKind::BinaryOperator | EntityKind::CompoundAssignOperator => {
                 // Handle assignments
                 let children: Vec<Entity> = child.get_children().into_iter().collect();
                 debug_println!("DEBUG STMT: BinaryOperator has {} children", children.len());
@@ -2449,7 +2449,10 @@ fn extract_loop_control_statements(entity: &Entity) -> Vec<Statement> {
 fn extract_loop_control_statement(entity: &Entity) -> Vec<Statement> {
     match entity.get_kind() {
         EntityKind::DeclStmt | EntityKind::CallExpr => extract_single_statement(entity),
-        EntityKind::BinaryOperator | EntityKind::UnaryOperator | EntityKind::UnexposedExpr => {
+        EntityKind::BinaryOperator
+        | EntityKind::CompoundAssignOperator
+        | EntityKind::UnaryOperator
+        | EntityKind::UnexposedExpr => {
             if let Some(expr) = extract_expression(entity) {
                 vec![expression_to_statement(expr, extract_location(entity))]
             } else {
@@ -2951,7 +2954,7 @@ fn extract_single_statement(entity: &Entity) -> Vec<Statement> {
 
             statements
         }
-        EntityKind::BinaryOperator => {
+        EntityKind::BinaryOperator | EntityKind::CompoundAssignOperator => {
             let children: Vec<Entity> = entity.get_children().into_iter().collect();
             if children.len() == 2 {
                 if let (Some(lhs), Some(rhs)) = (
@@ -3668,7 +3671,7 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
             debug_println!("  DEBUG EXTRACT: Returning None");
             None
         }
-        EntityKind::BinaryOperator => {
+        EntityKind::BinaryOperator | EntityKind::CompoundAssignOperator => {
             // Extract binary operation (e.g., i < 2, x == 0)
             let children: Vec<Entity> = entity.get_children().into_iter().collect();
             debug_println!(

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -2295,6 +2295,9 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
             EntityKind::SwitchStmt => {
                 statements.push(extract_switch_statement(&child));
             }
+            EntityKind::TryStmt => {
+                statements.extend(extract_try_statement(&child));
+            }
             EntityKind::UnaryOperator => {
                 // Handle standalone dereference operations
                 if let Some(expr) = extract_expression(&child) {
@@ -2779,6 +2782,28 @@ fn extract_switch_body_statement(entity: &Entity) -> Vec<Statement> {
     }
 }
 
+fn extract_try_statement(entity: &Entity) -> Vec<Statement> {
+    let mut statements = Vec::new();
+
+    for child in entity.get_children() {
+        match child.get_kind() {
+            EntityKind::CompoundStmt => {
+                statements.extend(extract_compound_statement(&child));
+            }
+            EntityKind::CatchStmt => {
+                for catch_child in child.get_children() {
+                    if catch_child.get_kind() == EntityKind::CompoundStmt {
+                        statements.extend(extract_compound_statement(&catch_child));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    statements
+}
+
 // Extract one statement cursor used where C++ allows an unbraced substatement,
 // such as `if (x) f();` or `while (x) ++i;`. This helper intentionally takes
 // the already-selected branch/body cursor; callers must not pass a whole IfStmt
@@ -2788,6 +2813,7 @@ fn extract_single_statement(entity: &Entity) -> Vec<Statement> {
 
     match entity.get_kind() {
         EntityKind::CompoundStmt => extract_compound_statement(entity),
+        EntityKind::TryStmt => extract_try_statement(entity),
         EntityKind::DeclStmt => {
             let mut statements = Vec::new();
 

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -649,6 +649,7 @@ pub enum Expression {
     // Lambda expression with captures
     Lambda {
         captures: Vec<LambdaCaptureKind>,
+        capture_initializers: Vec<Expression>,
         body: Vec<Statement>,
     },
     // C++ cast expression (static_cast, dynamic_cast, reinterpret_cast, const_cast, C-style)
@@ -2992,6 +2993,59 @@ fn extract_cast_expression(entity: &Entity, kind: CastKind) -> Option<Expression
     })
 }
 
+fn extract_lambda_capture_tokens(entity: &Entity) -> Vec<String> {
+    let Some(range) = entity.get_range() else {
+        return Vec::new();
+    };
+
+    let mut capture_tokens = Vec::new();
+    let mut in_capture_list = false;
+
+    for token in safe_tokenize(&range) {
+        let spelling = token.get_spelling();
+        if spelling == "[" {
+            in_capture_list = true;
+            continue;
+        }
+        if spelling == "]" {
+            break;
+        }
+        if in_capture_list {
+            capture_tokens.push(spelling);
+        }
+    }
+
+    capture_tokens
+}
+
+fn extract_lambda_capture_initializer(
+    entity: &Entity,
+    capture_tokens: &[String],
+) -> Option<Expression> {
+    if entity.get_kind() == EntityKind::UnexposedExpr {
+        if let Some(ref_entity) = entity.get_reference() {
+            if matches!(
+                ref_entity.get_kind(),
+                EntityKind::FunctionDecl | EntityKind::Method | EntityKind::Constructor
+            ) {
+                if let Some(name) = ref_entity.get_name() {
+                    let has_call_syntax = capture_tokens
+                        .windows(2)
+                        .any(|window| window[0] == name && window[1] == "(");
+                    if has_call_syntax {
+                        return Some(Expression::FunctionCall {
+                            name,
+                            args: Vec::new(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    extract_expression(entity)
+}
+
 fn extract_expression(entity: &Entity) -> Option<Expression> {
     match entity.get_kind() {
         EntityKind::DeclRefExpr => {
@@ -3846,7 +3900,9 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
             debug_println!("DEBUG LAMBDA PARSER: Found LambdaExpr!");
 
             let mut captures = Vec::new();
+            let mut capture_initializers = Vec::new();
             let mut body = Vec::new();
+            let capture_tokens = extract_lambda_capture_tokens(entity);
 
             // Collect all VariableRef entries (these are the captured variables)
             let mut var_refs: Vec<String> = Vec::new();
@@ -3878,6 +3934,9 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                         if let Some(var_name) = child.get_name() {
                             decl_refs.insert(var_name);
                         }
+                        if let Some(expr) = extract_expression(&child) {
+                            capture_initializers.push(expr);
+                        }
                     }
                     EntityKind::CallExpr => {
                         // CallExpr with 'move' indicates a move capture [y = std::move(x)]
@@ -3885,6 +3944,16 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                             if name == "move" {
                                 has_move_call = true;
                             }
+                        }
+                        if let Some(expr) = extract_expression(&child) {
+                            capture_initializers.push(expr);
+                        }
+                    }
+                    EntityKind::UnexposedExpr => {
+                        if let Some(expr) =
+                            extract_lambda_capture_initializer(&child, &capture_tokens)
+                        {
+                            capture_initializers.push(expr);
                         }
                     }
                     EntityKind::ThisExpr => {
@@ -4033,7 +4102,11 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                 captures
             );
 
-            Some(Expression::Lambda { captures, body })
+            Some(Expression::Lambda {
+                captures,
+                capture_initializers,
+                body,
+            })
         }
         EntityKind::ArraySubscriptExpr => {
             // Array subscript: arr[i], data[idx], ptr[n], etc.

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -506,6 +506,13 @@ pub struct Variable {
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
+pub struct SwitchCase {
+    pub label: Option<Expression>,
+    pub statements: Vec<Statement>,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum Statement {
     VariableDecl(Variable),
     Assignment {
@@ -540,6 +547,11 @@ pub enum Statement {
         condition: Expression,
         then_branch: Vec<Statement>,
         else_branch: Option<Vec<Statement>>,
+        location: SourceLocation,
+    },
+    Switch {
+        condition: Expression,
+        cases: Vec<SwitchCase>,
         location: SourceLocation,
     },
     // Expression statements (e.g., standalone dereference, method calls)
@@ -2249,6 +2261,9 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                     location: extract_location(&child),
                 });
             }
+            EntityKind::SwitchStmt => {
+                statements.push(extract_switch_statement(&child));
+            }
             EntityKind::UnaryOperator => {
                 // Handle standalone dereference operations
                 if let Some(expr) = extract_expression(&child) {
@@ -2355,6 +2370,82 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
     }
 
     statements
+}
+
+fn extract_switch_statement(entity: &Entity) -> Statement {
+    let children: Vec<Entity> = entity.get_children().into_iter().collect();
+    let condition = children
+        .iter()
+        .find(|child| child.get_kind() != EntityKind::CompoundStmt)
+        .and_then(extract_expression)
+        .unwrap_or_else(|| Expression::Literal("true".to_string()));
+
+    let mut cases = Vec::new();
+    if let Some(body) = children
+        .iter()
+        .find(|child| child.get_kind() == EntityKind::CompoundStmt)
+    {
+        let mut current_case: Option<SwitchCase> = None;
+
+        for child in body.get_children() {
+            match child.get_kind() {
+                EntityKind::CaseStmt => {
+                    if let Some(case) = current_case.take() {
+                        cases.push(case);
+                    }
+
+                    let case_children: Vec<Entity> = child.get_children().into_iter().collect();
+                    let label = case_children.first().and_then(extract_expression);
+                    let mut statements = Vec::new();
+                    for stmt_child in case_children.iter().skip(1) {
+                        statements.extend(extract_switch_body_statement(stmt_child));
+                    }
+
+                    current_case = Some(SwitchCase { label, statements });
+                }
+                EntityKind::DefaultStmt => {
+                    if let Some(case) = current_case.take() {
+                        cases.push(case);
+                    }
+
+                    let mut statements = Vec::new();
+                    for stmt_child in child.get_children() {
+                        statements.extend(extract_switch_body_statement(&stmt_child));
+                    }
+
+                    current_case = Some(SwitchCase {
+                        label: None,
+                        statements,
+                    });
+                }
+                EntityKind::BreakStmt => {}
+                _ => {
+                    if let Some(case) = &mut current_case {
+                        case.statements
+                            .extend(extract_switch_body_statement(&child));
+                    }
+                }
+            }
+        }
+
+        if let Some(case) = current_case {
+            cases.push(case);
+        }
+    }
+
+    Statement::Switch {
+        condition,
+        cases,
+        location: extract_location(entity),
+    }
+}
+
+fn extract_switch_body_statement(entity: &Entity) -> Vec<Statement> {
+    match entity.get_kind() {
+        EntityKind::BreakStmt => Vec::new(),
+        EntityKind::CompoundStmt => extract_compound_statement(entity),
+        _ => extract_single_statement(entity),
+    }
 }
 
 // Extract one statement cursor used where C++ allows an unbraced substatement,

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -3061,6 +3061,19 @@ fn extract_expression(entity: &Entity) -> Option<Expression> {
                 args,
             })
         }
+        EntityKind::InitListExpr => {
+            let mut children = entity
+                .get_children()
+                .into_iter()
+                .filter_map(|child| extract_expression(&child));
+            let first = children.next()?;
+
+            Some(children.fold(first, |left, right| Expression::BinaryOp {
+                left: Box::new(left),
+                op: ",".to_string(),
+                right: Box::new(right),
+            }))
+        }
         EntityKind::CallExpr => {
             // Extract function call as expression
             let children: Vec<Entity> = entity.get_children().into_iter().collect();

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -2254,9 +2254,18 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                 let mut then_branch = Vec::new();
                 let mut else_branch = None;
 
+                let mut start_index = 0;
+                if children
+                    .first()
+                    .is_some_and(|child| child.get_kind() == EntityKind::DeclStmt)
+                {
+                    statements.extend(extract_single_statement(&children[0]));
+                    start_index = 1;
+                }
+
                 // Parse the if statement structure
                 let mut condition_seen = false;
-                let mut i = 0;
+                let mut i = start_index;
                 while i < children.len() {
                     let child_kind = children[i].get_kind();
 
@@ -2293,6 +2302,7 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                 });
             }
             EntityKind::SwitchStmt => {
+                statements.extend(extract_switch_init_statements(&child));
                 statements.push(extract_switch_statement(&child));
             }
             EntityKind::TryStmt => {
@@ -2719,6 +2729,7 @@ fn extract_switch_statement(entity: &Entity) -> Statement {
     let children: Vec<Entity> = entity.get_children().into_iter().collect();
     let condition = children
         .iter()
+        .skip_while(|child| child.get_kind() == EntityKind::DeclStmt)
         .find(|child| child.get_kind() != EntityKind::CompoundStmt)
         .and_then(extract_expression)
         .unwrap_or_else(|| Expression::Literal("true".to_string()));
@@ -2789,6 +2800,91 @@ fn extract_switch_body_statement(entity: &Entity) -> Vec<Statement> {
         EntityKind::CompoundStmt => extract_compound_statement(entity),
         _ => extract_single_statement(entity),
     }
+}
+
+fn extract_switch_init_statements(entity: &Entity) -> Vec<Statement> {
+    let children: Vec<Entity> = entity.get_children().into_iter().collect();
+    if children
+        .first()
+        .is_some_and(|child| child.get_kind() == EntityKind::DeclStmt)
+    {
+        extract_single_statement(&children[0])
+    } else {
+        extract_switch_init_calls_from_tokens(entity)
+    }
+}
+
+fn extract_switch_init_calls_from_tokens(entity: &Entity) -> Vec<Statement> {
+    let Some(range) = entity.get_range() else {
+        return Vec::new();
+    };
+
+    let tokens = safe_tokenize(&range);
+    let open_idx = match tokens.iter().position(|token| token.get_spelling() == "(") {
+        Some(idx) => idx,
+        None => return Vec::new(),
+    };
+
+    let mut paren_depth = 0usize;
+    let mut semicolon_idx = None;
+    for (idx, token) in tokens.iter().enumerate().skip(open_idx) {
+        match token.get_spelling().as_str() {
+            "(" => paren_depth += 1,
+            ")" => paren_depth = paren_depth.saturating_sub(1),
+            ";" if paren_depth == 1 => {
+                semicolon_idx = Some(idx);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let Some(semicolon_idx) = semicolon_idx else {
+        return Vec::new();
+    };
+
+    let init_tokens: Vec<String> = tokens[open_idx + 1..semicolon_idx]
+        .iter()
+        .map(|token| token.get_spelling())
+        .collect();
+
+    let mut statements = Vec::new();
+    for (idx, spelling) in init_tokens.iter().enumerate() {
+        if !is_possible_call_token(spelling) {
+            continue;
+        }
+
+        if init_tokens.get(idx + 1).is_some_and(|next| next == "(") {
+            statements.push(Statement::FunctionCall {
+                name: qualified_call_name_from_tokens(&init_tokens, idx),
+                args: Vec::new(),
+                location: extract_location(entity),
+            });
+        }
+    }
+
+    statements
+}
+
+fn is_possible_call_token(token: &str) -> bool {
+    token
+        .chars()
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        && !is_cpp_keyword(token)
+}
+
+fn qualified_call_name_from_tokens(tokens: &[String], name_idx: usize) -> String {
+    let mut start_idx = name_idx;
+    while start_idx >= 2 && tokens[start_idx - 1] == "::" {
+        let qualifier = &tokens[start_idx - 2];
+        if !is_possible_call_token(qualifier) {
+            break;
+        }
+        start_idx -= 2;
+    }
+
+    tokens[start_idx..=name_idx].join("")
 }
 
 fn extract_try_statement(entity: &Entity) -> Vec<Statement> {

--- a/src/parser/ast_visitor.rs
+++ b/src/parser/ast_visitor.rs
@@ -2200,6 +2200,7 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
                 statements.push(Statement::ExitLoop);
             }
             EntityKind::ForStmt | EntityKind::WhileStmt | EntityKind::DoStmt => {
+                statements.extend(extract_loop_control_statements(&child));
                 statements.push(Statement::EnterLoop);
 
                 let loop_children: Vec<Entity> = child.get_children().into_iter().collect();
@@ -2385,6 +2386,41 @@ fn extract_compound_statement(entity: &Entity) -> Vec<Statement> {
     }
 
     statements
+}
+
+fn extract_loop_control_statements(entity: &Entity) -> Vec<Statement> {
+    let children: Vec<Entity> = entity.get_children().into_iter().collect();
+    if children.is_empty() {
+        return Vec::new();
+    }
+
+    let control_children = match entity.get_kind() {
+        EntityKind::ForStmt | EntityKind::WhileStmt => {
+            children.split_last().map(|(_, control)| control)
+        }
+        EntityKind::DoStmt => children.split_first().map(|(_, control)| control),
+        _ => None,
+    };
+
+    control_children
+        .into_iter()
+        .flatten()
+        .flat_map(extract_loop_control_statement)
+        .collect()
+}
+
+fn extract_loop_control_statement(entity: &Entity) -> Vec<Statement> {
+    match entity.get_kind() {
+        EntityKind::DeclStmt | EntityKind::CallExpr => extract_single_statement(entity),
+        EntityKind::BinaryOperator | EntityKind::UnaryOperator | EntityKind::UnexposedExpr => {
+            if let Some(expr) = extract_expression(entity) {
+                vec![expression_to_statement(expr, extract_location(entity))]
+            } else {
+                Vec::new()
+            }
+        }
+        _ => Vec::new(),
+    }
 }
 
 fn extract_range_for_control_statements(entity: &Entity) -> Vec<Statement> {

--- a/tests/test_array_subscript_safety.rs
+++ b/tests/test_array_subscript_safety.rs
@@ -1,0 +1,42 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn array_subscripts_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("array_subscript_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+// @safe
+int f() {
+    int arr[4] = {1, 2, 3, 4};
+    return arr[get_raw_int()];
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls inside array subscript expressions. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int"),
+        "array subscript unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_automated_annotator.rs
+++ b/tests/test_automated_annotator.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn annotate_safety_marks_unannotated_functions() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("annotate_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+int good() {
+    return 1;
+}
+
+int bad() {
+    return get_raw_int();
+}
+
+int wrapper() {
+    return bad();
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg("--annotate-safety")
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "annotator should succeed. stdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+
+    let annotated = fs::read_to_string(&file_path).expect("read annotated source");
+    assert!(
+        annotated.contains("// @safe\nint good()"),
+        "good function should be annotated safe:\n{}",
+        annotated
+    );
+    assert!(
+        annotated.contains("// @unsafe\nint bad()"),
+        "bad function should be annotated unsafe:\n{}",
+        annotated
+    );
+    assert!(
+        annotated.contains("// @unsafe\nint wrapper()"),
+        "wrapper should become unsafe after bad is discovered unsafe:\n{}",
+        annotated
+    );
+    assert_eq!(
+        annotated.matches("// @unsafe\nint get_raw_int();").count(),
+        1,
+        "existing unsafe annotation should not be duplicated:\n{}",
+        annotated
+    );
+}

--- a/tests/test_brace_init_safety.rs
+++ b/tests/test_brace_init_safety.rs
@@ -1,0 +1,48 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn brace_initializers_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("brace_init_safety.cpp");
+    let include_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("include");
+
+    fs::write(
+        &file_path,
+        r#"
+#include <rusty/box.hpp>
+
+// @unsafe
+int get_raw_int();
+
+// @safe
+int f() {
+    int x{get_raw_int()};
+    int y = int{get_raw_int()};
+    return x + y;
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .arg("-I")
+        .arg(include_dir)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls nested inside brace initializers. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int"),
+        "brace initializer unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_cast_expression_safety.rs
+++ b/tests/test_cast_expression_safety.rs
@@ -1,0 +1,47 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn cast_expressions_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("cast_expression_safety.cpp");
+    let include_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("include");
+
+    fs::write(
+        &file_path,
+        r#"
+#include <rusty/box.hpp>
+
+// @unsafe
+int get_raw_int();
+
+// @safe
+int f() {
+    int x = static_cast<int>(get_raw_int());
+    return static_cast<int>(get_raw_int());
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .arg("-I")
+        .arg(include_dir)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls nested inside casts. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int"),
+        "cast expression unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_compound_assignment_safety.rs
+++ b/tests/test_compound_assignment_safety.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn compound_assignment_rhs_is_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("compound_assignment_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+// @safe
+void f() {
+    int x = 0;
+    x += get_raw_int();
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "expected unsafe call in compound assignment RHS to fail. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int"),
+        "expected diagnostic to mention unsafe compound assignment RHS call. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_conditional_expression_safety.rs
+++ b/tests/test_conditional_expression_safety.rs
@@ -1,0 +1,69 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_checker(source: &str) -> String {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("conditional_expression_safety.cpp");
+    let include_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("include");
+
+    fs::write(&file_path, source).expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .arg("-I")
+        .arg(include_dir)
+        .output()
+        .expect("run checker");
+
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn ternary_expressions_are_checked_for_unsafe_calls() {
+    let output = run_checker(
+        r#"
+#include <rusty/box.hpp>
+
+// @unsafe
+int get_raw_int();
+
+// @safe
+void f(bool cond) {
+    int x = cond ? get_raw_int() : 0;
+}
+"#,
+    );
+
+    assert!(
+        output.contains("get_raw_int"),
+        "ternary unsafe call should be reported. Output: {}",
+        output
+    );
+}
+
+#[test]
+fn logical_expressions_with_bool_literals_are_checked_for_unsafe_calls() {
+    let output = run_checker(
+        r#"
+#include <rusty/box.hpp>
+
+// @unsafe
+int get_raw_int();
+
+// @safe
+void f() {
+    if (get_raw_int() && true) {
+    }
+    if (false || get_raw_int()) {
+    }
+}
+"#,
+    );
+
+    assert!(
+        output.contains("get_raw_int"),
+        "logical expression unsafe call should be reported. Output: {}",
+        output
+    );
+}

--- a/tests/test_constructor_initializer_safety.rs
+++ b/tests/test_constructor_initializer_safety.rs
@@ -1,0 +1,43 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn constructor_initializers_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("constructor_initializer_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+struct S {
+    int x;
+
+    // @safe
+    S() : x(get_raw_int()) {}
+};
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls in constructor initializers. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int") && stdout.contains("constructor initializer"),
+        "constructor initializer unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_for_loop_control.rs
+++ b/tests/test_for_loop_control.rs
@@ -1,0 +1,47 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn for_loop_initializer_is_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("for_loop_control.cpp");
+    let include_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("include");
+
+    fs::write(
+        &file_path,
+        r#"
+#include <rusty/box.hpp>
+
+// @unsafe
+int get_raw_int();
+
+// @safe
+void f() {
+    for (int i = get_raw_int(); i < 30; ++i) {
+    }
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .arg("-I")
+        .arg(include_dir)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls in for-loop initializers. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int"),
+        "for-loop initializer unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_function_call_arguments.rs
+++ b/tests/test_function_call_arguments.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn safe_function_call_arguments_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("function_call_arguments.cpp");
+    let include_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("include");
+
+    fs::write(
+        &file_path,
+        r#"
+#include <rusty/box.hpp>
+
+// @unsafe
+int get_raw_int();
+
+// @safe
+void sink(int);
+
+// @safe
+void f() {
+    sink(get_raw_int());
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .arg("-I")
+        .arg(include_dir)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls in safe function arguments. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int"),
+        "unsafe argument call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_lambda_body_safety.rs
+++ b/tests/test_lambda_body_safety.rs
@@ -1,0 +1,94 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn lambda_bodies_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("lambda_body_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+// @safe
+void takes_lambda(auto f) {
+    f();
+}
+
+// @safe
+void f() {
+    auto local = []() {
+        get_raw_int();
+    };
+
+    takes_lambda([]() {
+        get_raw_int();
+    });
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls inside lambda bodies. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int") && stdout.contains("lambda body"),
+        "lambda body unsafe call should be reported. Output: {}",
+        stdout
+    );
+}
+
+#[test]
+fn unsafe_blocks_inside_lambda_bodies_are_allowed() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("lambda_body_unsafe_block.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+// @safe
+void f() {
+    auto local = []() {
+        // @unsafe
+        {
+            get_raw_int();
+        }
+    };
+
+    local();
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "checker should allow unsafe calls inside explicit unsafe lambda blocks. stdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+}

--- a/tests/test_lambda_capture_initializer_safety.rs
+++ b/tests/test_lambda_capture_initializer_safety.rs
@@ -1,0 +1,43 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn lambda_capture_initializers_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("lambda_capture_initializer_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+// @safe
+void f() {
+    auto local = [x = get_raw_int()]() {
+        return x;
+    };
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls in lambda capture initializers. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int") && stdout.contains("lambda capture initializer"),
+        "lambda capture initializer unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_member_access_safety.rs
+++ b/tests/test_member_access_safety.rs
@@ -1,0 +1,50 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn member_access_receivers_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("member_access_safety.cpp");
+    let include_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("include");
+
+    fs::write(
+        &file_path,
+        r#"
+#include <rusty/box.hpp>
+
+struct S {
+    int x;
+};
+
+// @unsafe
+S get_raw_s();
+
+// @safe
+void f() {
+    int x = get_raw_s().x;
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .arg("-I")
+        .arg(include_dir)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls used as member access receivers. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_s"),
+        "member access receiver unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_new_expression_safety.rs
+++ b/tests/test_new_expression_safety.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn new_expressions_are_checked_for_nested_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("new_expression_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+// @safe
+int* f() {
+    return new int(get_raw_int());
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls nested inside new expressions. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int"),
+        "new expression unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_range_for.rs
+++ b/tests/test_range_for.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn range_for_expression_is_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("range_for.cpp");
+    let include_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("include");
+
+    fs::write(
+        &file_path,
+        r#"
+#include <vector>
+#include <rusty/box.hpp>
+
+// @unsafe
+std::vector<int>& get_vec_raw();
+
+// @safe
+void f() {
+    for (int x : get_vec_raw()) {
+        // do something
+    }
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .arg("-I")
+        .arg(include_dir)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls in range-for expressions. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_vec_raw"),
+        "range-for expression unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_selection_init_safety.rs
+++ b/tests/test_selection_init_safety.rs
@@ -1,0 +1,53 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn selection_init_statements_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("selection_init_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int unsafe_if_init();
+
+// @unsafe
+int unsafe_switch_init();
+
+// @safe
+void f() {
+    if (int x = unsafe_if_init(); x > 0) {}
+
+    switch (int y = unsafe_switch_init(); y) {
+        case 0:
+            break;
+    }
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "expected unsafe calls in selection init statements to fail. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("unsafe_if_init"),
+        "expected diagnostic to mention unsafe if init call. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("unsafe_switch_init"),
+        "expected diagnostic to mention unsafe switch init call. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_switch_case.rs
+++ b/tests/test_switch_case.rs
@@ -1,0 +1,53 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn switch_case_bodies_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("switch_case.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+void dangerous_case() {}
+void dangerous_default() {}
+
+// @safe
+void test_switch(int mode) {
+    switch (mode) {
+        case 1:
+            dangerous_case();
+            break;
+        default:
+            dangerous_default();
+            break;
+    }
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls inside switch cases. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("dangerous_case"),
+        "case body unsafe call should be reported. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("dangerous_default"),
+        "default body unsafe call should be reported. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_throw_expression_safety.rs
+++ b/tests/test_throw_expression_safety.rs
@@ -1,0 +1,40 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn throw_operands_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("throw_expression_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+int get_raw_int();
+
+// @safe
+void f() {
+    throw get_raw_int();
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "expected unsafe call in throw operand to fail. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("get_raw_int"),
+        "expected diagnostic to mention unsafe throw operand call. Output: {}",
+        stdout
+    );
+}

--- a/tests/test_try_catch_safety.rs
+++ b/tests/test_try_catch_safety.rs
@@ -1,0 +1,48 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn try_and_catch_bodies_are_checked_for_unsafe_calls() {
+    let dir = TempDir::new().expect("create temp dir");
+    let file_path = dir.path().join("try_catch_safety.cpp");
+
+    fs::write(
+        &file_path,
+        r#"
+// @unsafe
+void unsafe_in_try();
+
+// @unsafe
+void unsafe_in_catch();
+
+// @safe
+void f() {
+    try {
+        unsafe_in_try();
+    } catch (...) {
+        unsafe_in_catch();
+    }
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rusty-cpp-checker"))
+        .arg(&file_path)
+        .output()
+        .expect("run checker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "checker should reject unsafe calls inside try/catch bodies. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("unsafe_in_try") && stdout.contains("unsafe_in_catch"),
+        "try and catch unsafe calls should both be reported. Output: {}",
+        stdout
+    );
+}


### PR DESCRIPTION
  ## Summary

  Adds an automated safety annotator mode for RustyCpp. Users can now run the checker with `--annotate-safety` to edit a source file in place and insert `// @safe` or `// @unsafe` above unannotated functions.

  ## How It Works

  The annotator reuses RustyCpp’s existing parser and analyzer instead of implementing a separate safety classifier.

  When `--annotate-safety` is enabled, RustyCpp:

  1. Parses the target translation unit using the same include paths, defines, compile database handling, and clang arguments as normal analysis.
  2. Collects functions and methods defined in the input source file.
  3. Skips functions that already have an explicit `// @safe`, `// @unsafe`, or `// @bridge` annotation.
  4. Creates a temporary annotated copy of the file where all remaining unannotated functions are initially marked `// @safe`.
  5. Runs the normal RustyCpp checker on that temporary file.
  6. Any function that produces safety violations is reclassified as `// @unsafe`.
  7. Repeats this process until no more functions change classification.
  8. Writes the final annotations back into the original source file.

  The repeated pass is necessary for transitive safety. For example, if `bad()` is discovered to be unsafe, then a previously safe-looking `wrapper()` that calls `bad()` must also become unsafe on the next
  pass.

  ## Example

  ```cpp
  // @unsafe
  int get_raw_int();

  int good() {
      return 1;
  }

  int bad() {
      return get_raw_int();
  }

  int wrapper() {
      return bad();
  }

  After running:

  rusty-cpp-checker --annotate-safety file.cpp

  RustyCpp produces:

  // @unsafe
  int get_raw_int();

  // @safe
  int good() {
      return 1;
  }

  // @unsafe
  int bad() {
      return get_raw_int();
  }

  // @unsafe
  int wrapper() {
      return bad();
  }

  ## Testing

  Added an integration test covering:

  - Safe annotation insertion.
  - Unsafe annotation insertion.
  - Transitive unsafe propagation through callers.
  - Avoiding duplicate annotations on already annotated functions.
