### PR TITLE
codegen: cxx-namespace wrap re-qualifies crate-root item self-references (#37)

### DIFF
--- a/transpiler/src/codegen/mod.rs
+++ b/transpiler/src/codegen/mod.rs
@@ -5019,6 +5019,30 @@ impl CodeGen {
             // `ns` is guaranteed to be Some here because we only set
             // `cxx_namespace_opened` when it was.
             if let Some(ns) = self.cxx_namespace.clone() {
+                // Re-qualify crate-root item self-references. The expression
+                // emitters conservatively global-qualify crate-local free-fn/
+                // const references as `::<item>` — correct in the legacy
+                // flat-export mode where items land at global scope, but once
+                // this namespace wraps the purview those refs look in the
+                // (empty) global namespace and miss. Same gap
+                // `wrap_module_purview_in_crate_namespace` closes with its
+                // Rule 4; same mechanics here: every declared item name,
+                // C++-escaped to match emission, rewritten `::<item>` →
+                // `::<ns>::<item>` by the boundary-aware
+                // `requalify_crate_root_symbol` (leaves `x::item`, `.item(`,
+                // `>::item`, and already-qualified `::<ns>::item` alone).
+                // Sorted for deterministic output.
+                let mut root_items: Vec<String> = self
+                    .declared_item_names
+                    .iter()
+                    .map(|n| escape_cpp_keyword(n))
+                    .collect();
+                root_items.sort();
+                root_items.dedup();
+                for item in &root_items {
+                    self.output =
+                        Self::requalify_crate_root_symbol(&self.output, &ns, item);
+                }
                 self.writeln(&format!("}} // namespace {}", ns));
             }
         }

--- a/transpiler/tests/e2e_basic.rs
+++ b/transpiler/tests/e2e_basic.rs
@@ -1198,3 +1198,59 @@ fn test_auto_namespace_explicit_override_wins() {
         !cpp.contains("namespace btree_port::btree::map {"),
         "auto-derived namespace should not be used when explicit is given:\n{cpp}"    );
 }
+
+#[test]
+fn test_cxx_namespace_requalifies_crate_root_item_refs() {
+    // Issue #37: the expression emitters conservatively global-qualify
+    // crate-local free-fn references as `::callee` — fine in the legacy
+    // flat-export mode, but once `--cxx-namespace` wraps the purview
+    // those refs look in the (now-empty) global namespace and miss.
+    // The wrap-close must re-qualify them to `::<ns>::callee`, exactly
+    // as `wrap_module_purview_in_crate_namespace` does via its Rule 4.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("ns_requal.rs");
+    let output_path = dir.path().join("ns_requal.cppm");
+
+    std::fs::write(
+        &input,
+        r#"
+pub fn callee(x: i64) -> usize { if x > 0 { 1 } else { 2 } }
+pub fn caller(x: i64) -> usize { callee(x) }
+"#,
+    )
+    .unwrap();
+
+    let output = transpiler_bin()
+        .arg(input.to_str().unwrap())
+        .arg("--module-name")
+        .arg("foo")
+        .arg("--cxx-namespace")
+        .arg("foo::bar")
+        .arg("-o")
+        .arg(output_path.to_str().unwrap())
+        .output()
+        .expect("failed to run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let cpp = std::fs::read_to_string(&output_path).unwrap();
+    // The call may be emitted unqualified (resolves within the wrapping
+    // namespace) or fully qualified against it — but a bare global
+    // `::callee(` must NOT survive the wrap.
+    let bare_global = cpp
+        .match_indices("::callee(")
+        .any(|(pos, _)| !cpp[..pos].ends_with("foo::bar") && !cpp[..pos].ends_with("bar"));
+    assert!(
+        !bare_global,
+        "bare global-qualified crate-root call survived the namespace wrap:\n{cpp}"
+    );
+    // And the requalified (or unqualified) call still exists somewhere.
+    assert!(
+        cpp.contains("callee("),
+        "caller lost its call entirely:\n{cpp}"
+    );
+}


### PR DESCRIPTION
Fixes #37.

The expression emitters conservatively global-qualify crate-local free-fn/const references as `::<item>` — correct in legacy flat-export mode, but under `--cxx-namespace`/`--auto-namespace` those refs look in the (now-empty) global namespace and miss. This is the same gap `wrap_module_purview_in_crate_namespace` closes for the dep pipeline with its **Rule 4**; the CLI namespace wrap had no requalification pass.

**Fix**: at the wrap-close, rewrite `::<item>` → `::<ns>::<item>` for every declared crate-root item name (C++-escaped, sorted for determinism) using the existing boundary-aware `requalify_crate_root_symbol` (leaves `x::item`, `.item(`, `>::item`, already-qualified forms untouched; single pass, cannot double-prefix).

**Verification**:
- bin unit suite **1910/1910**
- `e2e_basic` **31/31** incl. new regression `test_cxx_namespace_requalifies_crate_root_item_refs`
- guard/runtime/trait/parity-matrix integration suites green; `parity_test_verification` **43/43**
- `either_parity_harness` fails identically on clean `main` in this environment (pre-existing, not touched)

**Real-world case**: the srpc crate (mako repo, `crates/srpc`) — `--auto-namespace` output for `srpc.wire.varint` (`::val_size`/`::buf_size` self-refs) and `srpc.wire.archive` now compiles under clang 22 / C++23 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9DLY5SDRooowERihphNQ1