### PR TITLE
codegen: sibling-module use-imports resolve under cxx-namespace mode (#38)

### DIFF
--- a/transpiler/src/codegen/emit_items.rs
+++ b/transpiler/src/codegen/emit_items.rs
@@ -5743,6 +5743,21 @@ impl CodeGen {
                                 .insert(sibling_module.clone())
                         {
                             self.writeln(&format!("import {};", sibling_module));
+                            // cxx-namespace mode: the sibling's names live under
+                            // its OWN namespace (`::srpc::wire::varint`), not at
+                            // global scope, so "accessible at the same name after
+                            // import" (the flat-export rationale for dropping the
+                            // using) does not hold there. Bridge the emitted
+                            // `seg::X` path shape with a namespace alias. (Not an
+                            // `import` line, so the module-import hoist leaves it
+                            // inside the namespace where it belongs.)
+                            if self.cxx_namespace.is_some() {
+                                let ns_path = sibling_module.replace('.', "::");
+                                self.writeln(&format!(
+                                    "namespace {} = ::{};",
+                                    first_segment, ns_path
+                                ));
+                            }
                             emitted_as_module_import = true;
                         } else if let Some(first_segment) = using_segments
                             .iter()
@@ -5755,6 +5770,32 @@ impl CodeGen {
                             // skip both the redundant import and the
                             // broken using path.
                             emitted_as_module_import = true;
+                        }
+                        // cxx-namespace mode, single-ITEM sibling import
+                        // (`use super::varint::VARINT_BUF_LEN`): downstream code
+                        // references the item BARE, so the alias alone is not
+                        // enough — emit a real using-declaration against the
+                        // sibling's namespace. (`pub use` re-exports keep their
+                        // `export` so downstream importers see the name.)
+                        if emitted_as_module_import
+                            && self.cxx_namespace.is_some()
+                            && let Some(first_segment) = using_segments
+                                .iter()
+                                .find(|seg| !seg.is_empty())
+                                .copied()
+                            && let Some(sibling_module) =
+                                self.resolve_sibling_module_path(first_segment)
+                            && let Some(item) = using_segments.last().copied()
+                            && !item.is_empty()
+                            && item != first_segment
+                        {
+                            let ns_path = sibling_module.replace('.', "::");
+                            self.writeln(&format!(
+                                "{}using ::{}::{};",
+                                export_prefix,
+                                ns_path,
+                                escape_cpp_keyword(item)
+                            ));
                         }
                         if !emitted_as_module_import {
                             // A plain import of a wrapped DEPENDENCY's MODULE


### PR DESCRIPTION
Fixes #38 (the sibling-import half; with #41's crate-root requalification the namespace mode becomes fully coherent).

In flat-export mode a sibling-module use-import emits `import sib;` and drops the `using` — correct there, since the sibling's names land at global scope. Under `--cxx-namespace`/`--auto-namespace` the sibling's names live in its **own** namespace, so both emitted reference shapes miss: path-qualified `seg::Item` (no `namespace seg` exists in the consumer) and bare single-item imports (`use super::varint::VARINT_BUF_LEN` → bare `VARINT_BUF_LEN`).

**Fix** — at the sibling-import site, additionally emit:
```cpp
namespace <seg> = ::<sibling::ns>;          // once per sibling module
[export ]using ::<sibling::ns>::<Item>;     // single-item imports
```
Both land inside the wrapping namespace (not `import` lines, so the module-import hoist leaves them in place); `pub use` re-exports keep `export`.

**Real-world case**: `srpc.wire.serde` (mako `crates/srpc`) — `use super::archive::{ReadArchive, WireError, WriteArchive}` path shapes and the `VARINT_BUF_LEN` bare reference. Verification against the full srpc chain is in flight on the merged stack (#41 + this + #42); will report in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9DLY5SDRooowERihphNQ1