### PR TITLE
codegen: primitive-impl self receivers + float byte-conversion lowerings (#40)

### DIFF
--- a/transpiler/src/codegen/emit_expr.rs
+++ b/transpiler/src/codegen/emit_expr.rs
@@ -7636,8 +7636,11 @@ impl CodeGen {
                 // Byte-array conversions: reinterpret the integer's object
                 // representation as std::array<uint8_t, sizeof(T)>. `to_ne_bytes`
                 // is native order; le/be pick the ordering via std::endian and
-                // std::byteswap (C++23).
-                if is_int && mc.args.is_empty() && method == "to_ne_bytes" {
+                // std::byteswap (C++23). Floats have these methods in Rust too
+                // (f32/f64::to_le_bytes etc.); std::byteswap is integral-only,
+                // so the float variants reverse the byte array instead —
+                // identical object-representation semantics.
+                if (is_int || is_float) && mc.args.is_empty() && method == "to_ne_bytes" {
                     return format!(
                         "([&]() {{ auto __v = {}; return std::bit_cast<std::array<uint8_t, sizeof(__v)>>(__v); }}())",
                         receiver
@@ -7652,6 +7655,18 @@ impl CodeGen {
                 if is_int && mc.args.is_empty() && method == "to_be_bytes" {
                     return format!(
                         "([&]() {{ auto __v = {}; using __A = std::array<uint8_t, sizeof(__v)>; if constexpr (std::endian::native == std::endian::big) {{ return std::bit_cast<__A>(__v); }} else {{ return std::bit_cast<__A>(std::byteswap(__v)); }} }}())",
+                        receiver
+                    );
+                }
+                if is_float && mc.args.is_empty() && method == "to_le_bytes" {
+                    return format!(
+                        "([&]() {{ auto __v = {}; auto __a = std::bit_cast<std::array<uint8_t, sizeof(__v)>>(__v); if constexpr (std::endian::native != std::endian::little) {{ std::reverse(__a.begin(), __a.end()); }} return __a; }}())",
+                        receiver
+                    );
+                }
+                if is_float && mc.args.is_empty() && method == "to_be_bytes" {
+                    return format!(
+                        "([&]() {{ auto __v = {}; auto __a = std::bit_cast<std::array<uint8_t, sizeof(__v)>>(__v); if constexpr (std::endian::native != std::endian::big) {{ std::reverse(__a.begin(), __a.end()); }} return __a; }}())",
                         receiver
                     );
                 }

--- a/transpiler/src/codegen/inference.rs
+++ b/transpiler/src/codegen/inference.rs
@@ -6601,6 +6601,20 @@ impl CodeGen {
                 if path.path.segments.is_empty() {
                     return None;
                 }
+                // `self` inside an `impl … for <primitive>` types as that
+                // primitive, so receiver-type-gated numeric lowerings
+                // (to_le_bytes, wrapping_*, …) fire in scalar-impl method
+                // bodies too — e.g. `impl Serialize for i8 { fn
+                // serialize(&self, …) { … self.to_le_bytes() … } }`.
+                // Deliberately narrow — primitive self types only — so
+                // struct-impl `self` inference is untouched.
+                if path.path.is_ident("self")
+                    && let Some(Some(self_ty)) = self.current_impl_method_self_tys.last()
+                    && (self.is_known_integer_like_type(self_ty)
+                        || self.is_known_float_like_type(self_ty))
+                {
+                    return Some(self_ty.clone());
+                }
                 // Primitive associated consts type as their owner (`i32::MAX`
                 // → i32) so receiver-type-gated method lowerings (overflowing_*,
                 // clamp, signum, …) fire on const-path receivers too. BITS-like

--- a/transpiler/src/codegen/mod.rs
+++ b/transpiler/src/codegen/mod.rs
@@ -17805,6 +17805,20 @@ impl CodeGen {
         self.indent += 1;
         let prev_struct = self.current_struct.clone();
         self.current_struct = Some("Self".to_string());
+        // Expose the impl's CONCRETE self type to body emission, mirroring
+        // emit_method's wrapper: infer_simple_expr_type reads the top of
+        // this stack to type a bare `self` receiver, which is what lets
+        // receiver-type-gated numeric lowerings (to_le_bytes, wrapping_*,
+        // …) fire inside primitive-target trait impls
+        // (`impl Serialize for i8 { … self.to_le_bytes() … }`, #40).
+        // A default method's `Self` is a template param — push None there.
+        self.current_impl_method_self_tys.push(
+            if method_spec.self_is_template_param {
+                None
+            } else {
+                Some(method_spec.self_ty.clone())
+            },
+        );
         // §3.2.13 body assoc-type resolution: for a DEFAULT method the body's
         // `Self::Assoc` must qualify to `typename Self_::Assoc` (dependent name),
         // not strip to a bare `Assoc`. Scope the flag to the template-`Self` body
@@ -18138,6 +18152,7 @@ impl CodeGen {
         self.pop_return_type_hint();
         self.pop_return_value_scope();
         self.current_struct_assoc_cpp_types.pop();
+        self.current_impl_method_self_tys.pop();
         self.current_struct = prev_struct;
         self.ufcs_template_self_body = prev_ufcs_template_self_body;
         self.ufcs_free_fn_body = prev_ufcs_free_fn_body;

--- a/transpiler/tests/e2e_basic.rs
+++ b/transpiler/tests/e2e_basic.rs
@@ -1198,3 +1198,60 @@ fn test_auto_namespace_explicit_override_wins() {
         !cpp.contains("namespace btree_port::btree::map {"),
         "auto-derived namespace should not be used when explicit is given:\n{cpp}"    );
 }
+
+#[test]
+fn test_primitive_impl_self_receiver_numeric_lowering() {
+    // Issue #40: `self` inside `impl … for <primitive>` must type as the
+    // primitive so the receiver-type-gated byte-conversion lowerings fire
+    // (scalar Serialize impls: `self.to_le_bytes()`); f64 exercises the
+    // float variant (std::byteswap is integral-only — floats reverse the
+    // byte array instead).
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("prim_self.rs");
+    let output_path = dir.path().join("prim_self.cppm");
+
+    std::fs::write(
+        &input,
+        r#"
+pub trait Ser { fn ser(&self) -> u8; }
+impl Ser for i32 {
+    fn ser(&self) -> u8 { self.to_le_bytes()[0] }
+}
+impl Ser for f64 {
+    fn ser(&self) -> u8 { self.to_le_bytes()[0] }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = transpiler_bin()
+        .arg(input.to_str().unwrap())
+        .arg("--module-name")
+        .arg("prim")
+        .arg("-o")
+        .arg(output_path.to_str().unwrap())
+        .output()
+        .expect("failed to run");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let cpp = std::fs::read_to_string(&output_path).unwrap();
+    // The raw member call must be gone in both impls…
+    assert!(
+        !cpp.contains("self_.to_le_bytes()"),
+        "raw member to_le_bytes survived on a scalar receiver:\n{cpp}"
+    );
+    // …replaced by the bit_cast lowering (int form uses byteswap on the
+    // big-endian path; float form reverses the array).
+    assert!(
+        cpp.contains("std::bit_cast"),
+        "bit_cast byte-conversion lowering missing:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("std::reverse"),
+        "float to_le_bytes variant (array reverse) missing:\n{cpp}"
+    );
+}


### PR DESCRIPTION
Fixes #40 (the remaining shapes — the local-receiver `to_le_bytes` lowering already existed).

Three coordinated pieces:
1. **Bare-`self` typing**: `infer_simple_expr_type` types a `self` path from `current_impl_method_self_tys` when the impl's self type is primitive (narrow gate — struct-impl `self` inference untouched), so every receiver-type-gated numeric lowering fires inside `impl … for <primitive>` bodies.
2. **UFCS emitter self-type push**: primitive-target trait impls lower through the extension free-fn emitter, which only set the synthetic `current_struct="Self"`; it now pushes `method_spec.self_ty` (None for default-method template `Self`) around body emission, mirroring `emit_method`'s wrapper — without this, (1) can't see the type.
3. **Float byte-conversions**: `to_ne_bytes` now fires for floats (plain bit_cast); `to_le/be_bytes` get float variants that reverse the byte array on endian mismatch (`std::byteswap` is integral-only).

**Verification**: bin unit suite **1910/1910**; `e2e_basic` **31/31** incl. new regression `test_primitive_impl_self_receiver_numeric_lowering` (i32 + f64 scalar impls).

**Real-world case**: `srpc.wire.serde` (mako `crates/srpc`) scalar Serialize/Deserialize impls — and with the full stack (#41 + #42 + #43 + this), **the entire srpc crate transpiles `--auto-namespace` and all six emitted modules compile under clang 22 / C++23 modules** (`srpc.wire.{varint,archive,frame,serde}`, `srpc.wire`, `srpc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9DLY5SDRooowERihphNQ1